### PR TITLE
feat(story): unassign when delete view_story permission

### DIFF
--- a/python/apps/taiga/src/taiga/permissions/services.py
+++ b/python/apps/taiga/src/taiga/permissions/services.py
@@ -193,3 +193,9 @@ def permissions_are_compatible(permissions: list[str]) -> bool:
         return False
 
     return True
+
+
+async def is_view_story_permission_deleted(old_permissions: list[str], new_permissions: list[str]) -> bool:
+    if "view_story" in old_permissions and "view_story" not in new_permissions:
+        return True
+    return False

--- a/python/apps/taiga/src/taiga/projects/memberships/repositories.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/repositories.py
@@ -21,6 +21,7 @@ from taiga.users.models import User
 
 DEFAULT_QUERYSET = ProjectMembership.objects.all()
 
+
 class ProjectMembershipFilters(TypedDict, total=False):
     project_id: UUID
     username: str

--- a/python/apps/taiga/src/taiga/stories/assignments/repositories.py
+++ b/python/apps/taiga/src/taiga/stories/assignments/repositories.py
@@ -27,6 +27,7 @@ class StoryAssignmentFilters(TypedDict, total=False):
     project_id: UUID
     story_id: UUID
     username: str
+    role_id: UUID
 
 
 def _apply_filters_to_queryset(
@@ -43,6 +44,9 @@ def _apply_filters_to_queryset(
 
     if "username" in filter_data:
         filter_data["user__username"] = filter_data.pop("username")
+
+    if "role_id" in filter_data:
+        filter_data["user__project_memberships__role_id"] = filter_data.pop("role_id")
 
     return qs.filter(**filter_data)
 

--- a/python/apps/taiga/tests/unit/taiga/permissions/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/permissions/test_services.py
@@ -299,3 +299,22 @@ def test_permissions_are_valid(permissions, expected):
 )
 def test_permissions_are_compatible(permissions, expected):
     assert services.permissions_are_compatible(permissions) == expected
+
+
+#####################################################
+# is_view_story_permission_deleted
+#####################################################
+
+
+async def test_is_view_story_permission_deleted_false():
+    old_permissions = ["view_project"]
+    new_permissions = ["view_story"]
+
+    assert await services.is_view_story_permission_deleted(old_permissions, new_permissions) is False
+
+
+async def test_is_view_story_permission_deleted_true():
+    old_permissions = ["view_story"]
+    new_permissions = ["view_project"]
+
+    assert await services.is_view_story_permission_deleted(old_permissions, new_permissions) is True


### PR DESCRIPTION
## Unassign when delete view_story permission

![](https://media.giphy.com/media/26BGIs6EwBamnsH28/giphy.gif)

### How to test
- [x] Review code
- [x] Tests are green

In postman:

Assign a story to a membership whose role has view_story permission
- [x] Change permissions of this role (now not view_story permission) and check that story_assignment is deleted

Assign a story to a membership whose role has view_story permission
- [x] Change role of this membership (one without view_story permission) and check that story_assignment is deleted