### PR TITLE
feat(stories): u#226 endpoint delete story

### DIFF
--- a/python/apps/taiga/src/taiga/projects/memberships/services/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/services/__init__.py
@@ -73,7 +73,7 @@ async def update_project_membership(membership: ProjectMembership, role_slug: st
 
     # Unassign stories for user if the new role doesn't have view_story permission
     if view_story_is_deleted:
-        await story_assignments_repositories.delete_story_assignment(
+        await story_assignments_repositories.delete_stories_assignments(
             filters={"project_id": membership.project_id, "username": membership.user.username}
         )
 

--- a/python/apps/taiga/src/taiga/projects/roles/services/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/roles/services/__init__.py
@@ -50,6 +50,6 @@ async def update_project_role_permissions(role: ProjectRole, permissions: list[s
 
     # Unassign stories for user if the new permissions don't have view_story
     if view_story_is_deleted:
-        await story_assignments_repositories.delete_story_assignment(filters={"role_id": role.id})
+        await story_assignments_repositories.delete_stories_assignments(filters={"role_id": role.id})
 
     return project_role_permissions

--- a/python/apps/taiga/src/taiga/stories/assignments/api/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/assignments/api/__init__.py
@@ -12,7 +12,7 @@ from taiga.base.api import AuthRequest
 from taiga.base.api.permissions import check_permissions
 from taiga.base.validators import B64UUID
 from taiga.exceptions import api as ex
-from taiga.exceptions.api.errors import ERROR_400, ERROR_403, ERROR_404, ERROR_422
+from taiga.exceptions.api.errors import ERROR_403, ERROR_404, ERROR_422
 from taiga.permissions import HasPerm
 from taiga.routers import routes
 from taiga.stories.assignments import services as story_assignments_services
@@ -64,7 +64,7 @@ async def create_story_assignment(
     "/{project_id}/stories/{ref}/assignments/{username}",
     name="project.story.assignments.delete",
     summary="Delete story assignment",
-    responses=ERROR_422 | ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_404 | ERROR_403,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_story_assignment(

--- a/python/apps/taiga/src/taiga/stories/assignments/repositories.py
+++ b/python/apps/taiga/src/taiga/stories/assignments/repositories.py
@@ -101,7 +101,7 @@ def get_story_assignment(
 
 
 @sync_to_async
-def delete_story_assignment(filters: StoryAssignmentFilters = {}) -> int:
+def delete_stories_assignments(filters: StoryAssignmentFilters = {}) -> int:
     qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
     count, _ = qs.delete()
     return count

--- a/python/apps/taiga/src/taiga/stories/assignments/services/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/assignments/services/__init__.py
@@ -53,10 +53,8 @@ async def get_story_assignment(project_id: UUID, ref: int, username: str) -> Sto
 
 
 async def delete_story_assignment(story_assignment: StoryAssignment) -> bool:
-    story_assignment_deleted = await story_assignments_repositories.delete_story_assignment(
-        filters={"id": story_assignment.id}
-    )
-    if story_assignment_deleted > 0:
+    deleted = await story_assignments_repositories.delete_stories_assignments(filters={"id": story_assignment.id})
+    if deleted > 0:
         await stories_assignments_events.emit_event_when_story_assignment_is_deleted(story_assignment=story_assignment)
         return True
     return False

--- a/python/apps/taiga/src/taiga/stories/stories/events/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/events/__init__.py
@@ -7,12 +7,18 @@
 
 from taiga.events import events_manager
 from taiga.projects.projects.models import Project
-from taiga.stories.stories.events.content import CreateStoryContent, ReorderStoriesContent, UpdateStoryContent
+from taiga.stories.stories.events.content import (
+    CreateStoryContent,
+    DeleteStoryContent,
+    ReorderStoriesContent,
+    UpdateStoryContent,
+)
 from taiga.stories.stories.serializers import ReorderStoriesSerializer, StoryDetailSerializer
 
 CREATE_STORY = "stories.create"
 UPDATE_STORY = "stories.update"
 REORDER_STORIES = "stories.reorder"
+DELETE_STORY = "stories.delete"
 
 
 async def emit_event_when_story_is_created(project: Project, story: StoryDetailSerializer) -> None:
@@ -41,4 +47,15 @@ async def emit_when_stories_are_reordered(project: Project, reorder: ReorderStor
         project=project,
         type=REORDER_STORIES,
         content=ReorderStoriesContent(reorder=reorder),
+    )
+
+
+async def emit_event_when_story_is_deleted(
+    project: Project,
+    ref: int,
+) -> None:
+    await events_manager.publish_on_project_channel(
+        project=project,
+        type=DELETE_STORY,
+        content=DeleteStoryContent(ref=ref),
     )

--- a/python/apps/taiga/src/taiga/stories/stories/events/content.py
+++ b/python/apps/taiga/src/taiga/stories/stories/events/content.py
@@ -20,3 +20,7 @@ class UpdateStoryContent(BaseModel):
 
 class ReorderStoriesContent(BaseModel):
     reorder: ReorderStoriesSerializer
+
+
+class DeleteStoryContent(BaseModel):
+    ref: int

--- a/python/apps/taiga/src/taiga/stories/stories/repositories.py
+++ b/python/apps/taiga/src/taiga/stories/stories/repositories.py
@@ -197,6 +197,18 @@ def bulk_update_stories(objs_to_update: list[Story], fields_to_update: list[str]
 
 
 ##########################################################
+# delete story
+##########################################################
+
+
+@sync_to_async
+def delete_stories(filters: StoryFilters = {}) -> int:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    count, _ = qs.delete()
+    return count
+
+
+##########################################################
 # misc
 ##########################################################
 

--- a/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
@@ -183,7 +183,7 @@ async def _validate_and_process_values_to_update(story: Story, values: dict[str,
 
 
 ##########################################################
-# reorder stories
+# update reorder stories
 ##########################################################
 
 
@@ -296,3 +296,17 @@ async def reorder_stories(
     await stories_events.emit_when_stories_are_reordered(project=project, reorder=reorder_story_serializer)
 
     return reorder_story_serializer
+
+
+##########################################################
+# delete story
+##########################################################
+
+
+async def delete_story(story: Story) -> bool:
+    deleted = await stories_repositories.delete_stories(filters={"id": story.id})
+    if deleted > 0:
+        await stories_events.emit_event_when_story_is_deleted(project=story.project, ref=story.ref)
+        return True
+
+    return False

--- a/python/apps/taiga/tests/integration/taiga/stories/assignments/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/assignments/test_repositories.py
@@ -47,13 +47,13 @@ async def test_get_story_assignment() -> None:
 
 
 ##########################################################
-# delete_story_assignment
+# delete_stories_assignments
 ##########################################################
 
 
-async def test_delete_story_assignment() -> None:
+async def test_delete_stories_assignments() -> None:
     story_assignment = await f.create_story_assignment()
-    story_assignment_deleted = await repositories.delete_story_assignment(
+    deleted = await repositories.delete_stories_assignments(
         filters={"story_id": story_assignment.story.id, "username": story_assignment.user.username},
     )
-    assert story_assignment_deleted == 1
+    assert deleted == 1

--- a/python/apps/taiga/tests/unit/taiga/projects/memberships/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/memberships/test_services.py
@@ -139,6 +139,6 @@ async def test_update_project_membership_role_view_story_deleted():
         fake_membership_events.emit_event_when_project_membership_is_updated.assert_awaited_once_with(
             membership=updated_membership
         )
-        fake_story_assignments_repository.delete_story_assignment.assert_awaited_once_with(
+        fake_story_assignments_repository.delete_stories_assignments.assert_awaited_once_with(
             filters={"project_id": project.id, "username": user.username}
         )

--- a/python/apps/taiga/tests/unit/taiga/projects/roles/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/roles/test_services.py
@@ -95,4 +95,6 @@ async def test_update_project_role_permissions_view_story_deleted():
         await services.update_project_role_permissions(role=role, permissions=permissions)
         fake_role_repository.update_project_role_permissions.assert_awaited_once()
         fake_roles_events.emit_event_when_project_role_permissions_are_updated.assert_awaited_with(role=role)
-        fake_story_assignments_repository.delete_story_assignment.assert_awaited_once_with(filters={"role_id": role.id})
+        fake_story_assignments_repository.delete_stories_assignments.assert_awaited_once_with(
+            filters={"role_id": role.id}
+        )

--- a/python/apps/taiga/tests/unit/taiga/stories/assignments/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/stories/assignments/test_services.py
@@ -178,12 +178,12 @@ async def test_delete_story_assignment_fail():
             "taiga.stories.assignments.services.stories_assignments_events", autospec=True
         ) as fake_stories_assignments_events,
     ):
-        fake_story_assignment_repo.delete_story_assignment.return_value = 0
+        fake_story_assignment_repo.delete_stories_assignments.return_value = 0
 
         await services.delete_story_assignment(story_assignment=story_assignment)
         fake_stories_assignments_events.emit_event_when_story_assignment_is_deleted.assert_not_awaited()
 
-        fake_story_assignment_repo.delete_story_assignment.assert_awaited_once_with(
+        fake_story_assignment_repo.delete_stories_assignments.assert_awaited_once_with(
             filters={"id": story_assignment.id},
         )
 
@@ -201,13 +201,13 @@ async def test_delete_story_assignment_ok():
             "taiga.stories.assignments.services.stories_assignments_events", autospec=True
         ) as fake_stories_assignments_events,
     ):
-        fake_story_assignment_repo.delete_story_assignment.return_value = 1
+        fake_story_assignment_repo.delete_stories_assignments.return_value = 1
 
         await services.delete_story_assignment(story_assignment=story_assignment)
         fake_stories_assignments_events.emit_event_when_story_assignment_is_deleted.assert_awaited_once_with(
             story_assignment=story_assignment
         )
 
-        fake_story_assignment_repo.delete_story_assignment.assert_awaited_once_with(
+        fake_story_assignment_repo.delete_stories_assignments.assert_awaited_once_with(
             filters={"id": story_assignment.id},
         )

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -338,7 +338,7 @@ Content for:
 
 #### `stories.update`
 
-It happens when an story has been updated.
+It happens when a story has been updated.
 
 Content for:
 - project channel:
@@ -375,6 +375,19 @@ Content for:
       }
   }
   ```
+
+#### `stories.delete`
+
+It happens when a story has been deleted.
+
+Content for:
+- project channel:
+  ```
+  {
+      "ref": "story ref (int)"
+  }
+  ```
+
 
 #### `stories_assignments.create`
 

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "402ea276-cc25-4ad8-868f-950dcd5ca835",
+		"_postman_id": "95fc3869-a038-4735-84fb-c63e1c37c655",
 		"name": "taiga-next",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9835734"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -499,7 +498,7 @@
 			"name": "workspaces",
 			"item": [
 				{
-					"name": "new workspace",
+					"name": "create workspace",
 					"event": [
 						{
 							"listen": "test",
@@ -680,7 +679,7 @@
 			"name": "projects",
 			"item": [
 				{
-					"name": "new project",
+					"name": "create project",
 					"event": [
 						{
 							"listen": "test",
@@ -944,7 +943,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"permissions\": [\n        \"view_story\",\n        \"modify_story\"\n    ]\n}",
+							"raw": "{\n    \"permissions\": [\n        \"view_us\",\n        \"modify_us\"\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1049,7 +1048,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"permissions\": [\n        \"view_story\",\n        \"modify_story\"\n    ]\n}",
+							"raw": "{\n    \"permissions\": [\n        \"view_us\",\n        \"modify_us\"\n    ]\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1337,7 +1336,12 @@
 									"type": "default",
 									"disabled": true
 								}
-							]
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}",
@@ -1770,10 +1774,10 @@
 			]
 		},
 		{
-			"name": "project stories",
+			"name": "stories",
 			"item": [
 				{
-					"name": "new story",
+					"name": "create story",
 					"event": [
 						{
 							"listen": "test",
@@ -1832,7 +1836,7 @@
 					"response": []
 				},
 				{
-					"name": "get stories",
+					"name": "list stories",
 					"event": [
 						{
 							"listen": "test",
@@ -1996,6 +2000,54 @@
 					"response": []
 				},
 				{
+					"name": "delete story",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"   pm.environment.set(\"story_version\", pm.response.json().version);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/stories/{{story_ref}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"stories",
+								"{{story_ref}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "reorder stories",
 					"event": [
 						{
@@ -2055,7 +2107,7 @@
 					"response": []
 				},
 				{
-					"name": "new story assignment",
+					"name": "create story assignment",
 					"event": [
 						{
 							"listen": "test",

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "a6159e64-d55f-44f0-8fdd-9baf71bbb673",
+		"_postman_id": "8608cba2-3c88-4cf3-880f-10c762b6cd75",
 		"name": "taiga-next e2e",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9835734"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -2508,12 +2507,125 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "200.projects.{p}.stories.{ref}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/stories/{{story_ref}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"stories",
+								"{{story_ref}}"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
 		{
 			"name": "projects.{p}.stories.{ref}.assignments",
 			"item": [
+				{
+					"name": "N/A 200.projects.{p}.workflows.{wf}.stories",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    pm.environment.set(\"story_ref\", jsonRes.ref);",
+									"    ",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"title\": \"story1\",\n    \"status\": \"done\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/{{wf-slug}}/stories",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"{{wf-slug}}",
+								"stories"
+							]
+						}
+					},
+					"response": []
+				},
 				{
 					"name": "200.projects.{p}.stories.{ref}.assignments",
 					"event": [


### PR DESCRIPTION
![](https://media.giphy.com/media/xULW8N9O5WD32L5052/giphy.gif)

This PR implements physical deletion of a story, as well as its assignments (if any).

How to review
- [x] check the code
- [x] tests are green
- [x] create a story (check it's in the database); delete the story (check it's not in the database)
- [x] create a story and assign to a member (check the assignment in the database); delete the story (check the assignment is not there anymore)
- [x] check the event is sent (according to the updated documentation)