### PR TITLE
fix(front): u#228 design review

### DIFF
--- a/javascript/apps/taiga/src/app/modules/project/components/assign-user/assign-user.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/components/assign-user/assign-user.component.html
@@ -21,6 +21,8 @@ Copyright (c) 2021-present Kaleidos Ventures SL
         class="assignees-wrapper"
         data-test="assignees-wrapper">
         <h2
+          tuiAutoFocus
+          tabindex="-1"
           id="assign-user-dialog-label"
           class="assignees-title"
           [ngClass]="{
@@ -45,8 +47,6 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               trackBy: trackByMember
             ">
             <button
-              [tuiAutoFocus]="i === 0 && !viewOnly"
-              tabindex="0"
               class="user-row"
               data-test="unassigned-member"
               [class.view-only]="viewOnly"

--- a/javascript/apps/taiga/src/app/modules/project/components/assign-user/assign-user.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/components/assign-user/assign-user.component.ts
@@ -116,6 +116,7 @@ export class AssignUserComponent implements OnInit, OnDestroy {
     if (currentUserAssigned) {
       assignedMembers.unshift(currentUser);
     }
+
     this.state.set({ assigned: assignedMembers });
   }
 
@@ -251,6 +252,8 @@ export class AssignUserComponent implements OnInit, OnDestroy {
   }
 
   public onAssign(event: Event, member: Membership['user']) {
+    event.preventDefault();
+    event.stopPropagation();
     this.assign.next(member);
     if (event.type === 'keydown') {
       const announcement = this.translocoService.translate(
@@ -276,6 +279,8 @@ export class AssignUserComponent implements OnInit, OnDestroy {
   }
 
   public onUnassign(event: Event, assignedUser: Membership['user']) {
+    event.preventDefault();
+    event.stopPropagation();
     this.unassign.next(assignedUser);
     if (event.type === 'keydown') {
       const announcement = this.translocoService.translate(

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/story/kanban-story.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/story/kanban-story.component.ts
@@ -9,6 +9,7 @@
 import { Location } from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   HostBinding,
@@ -90,7 +91,8 @@ export class KanbanStoryComponent implements OnChanges, OnInit {
     @Optional()
     @Inject(KanbanStatusComponent)
     private kabanStatus: KanbanStatusComponent,
-    private permissionService: PermissionsService
+    private permissionService: PermissionsService,
+    private cd: ChangeDetectorRef
   ) {
     this.state.set({
       assignees: [],
@@ -217,6 +219,7 @@ export class KanbanStoryComponent implements OnChanges, OnInit {
     if (!active) {
       this.closeAssignDropdown();
     }
+    this.cd.detectChanges();
   }
 
   public closeAssignDropdown() {


### PR DESCRIPTION
This pr solves:
- the multiple opened dropdown menus in kanban board with 'can view' permissions
- kanban board 'can edit' permissions and without assignees. When we try to assign someone with keyboard doesn't work