### PR TITLE
chore(workpaces): delete schemas and use serializers

### DIFF
--- a/python/apps/taiga/src/taiga/base/api/responses.py
+++ b/python/apps/taiga/src/taiga/base/api/responses.py
@@ -8,10 +8,9 @@
 from typing import Any
 
 from fastapi import status
-from taiga.base.serializers import BaseModel
 
-http_response_dict = dict[int | str, dict[str, type[BaseModel] | type[list[BaseModel]]]]
+Responses_t = dict[int | str, dict[str, Any]]
 
 
-def http_status_200(model: type[BaseModel] | type[list[Any]]) -> http_response_dict:
+def http_status_200(model: Any) -> Responses_t:
     return {status.HTTP_200_OK: {"model": model}}

--- a/python/apps/taiga/src/taiga/projects/projects/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/projects/serializers/__init__.py
@@ -7,7 +7,7 @@
 
 from taiga.base.serializers import UUIDB64, BaseModel
 from taiga.projects.projects.serializers.mixins import ProjectLogoMixin
-from taiga.workspaces.workspaces.serializers.related import WorkspaceSummarySerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceNestedSerializer
 
 
 class ProjectSummarySerializer(BaseModel, ProjectLogoMixin):
@@ -27,7 +27,7 @@ class ProjectDetailSerializer(BaseModel, ProjectLogoMixin):
     slug: str
     description: str | None = None
     color: int | None = None
-    workspace: WorkspaceSummarySerializer
+    workspace: WorkspaceNestedSerializer
 
     # User related fields
     user_is_admin: bool

--- a/python/apps/taiga/src/taiga/projects/projects/serializers/services.py
+++ b/python/apps/taiga/src/taiga/projects/projects/serializers/services.py
@@ -7,12 +7,12 @@
 
 from taiga.projects.projects.models import Project
 from taiga.projects.projects.serializers import ProjectDetailSerializer
-from taiga.workspaces.workspaces.serializers.related import WorkspaceSummarySerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceNestedSerializer
 
 
 def serialize_project_detail(
     project: Project,
-    workspace: WorkspaceSummarySerializer,
+    workspace: WorkspaceNestedSerializer,
     user_is_admin: bool,
     user_is_member: bool,
     user_has_pending_invitation: bool,

--- a/python/apps/taiga/src/taiga/projects/projects/services/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/projects/services/__init__.py
@@ -134,7 +134,7 @@ async def get_project_detail(project: Project, user: AnyUser) -> ProjectDetailSe
     ) = await permissions_services.get_user_workspace_role_info(user=user, workspace=project.workspace)
 
     user_id = None if user.is_anonymous else user.id
-    workspace = await workspaces_services.get_workspace_summary(id=project.workspace_id, user_id=user_id)
+    workspace = await workspaces_services.get_workspace_nested(id=project.workspace_id, user_id=user_id)
 
     user_permissions = await permissions_services.get_user_permissions_for_project(
         is_project_admin=is_project_admin,

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/repositories.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/repositories.py
@@ -216,13 +216,9 @@ def get_workspace(
 @sync_to_async
 def get_workspace_detail(
     user_id: UUID | None,
-    user_workspace_role_name: str,
-    user_projects_count: int,
     filters: WorkspaceFilters = {},
 ) -> Workspace | None:
     qs = _apply_filters_to_queryset(filters=filters, qs=DEFAULT_QUERYSET)
-    qs = qs.annotate(user_role=Value(user_workspace_role_name, output_field=CharField()))
-    qs = qs.annotate(total_projects=Value(user_projects_count, output_field=IntegerField()))
     qs = qs.annotate(has_projects=Exists(Project.objects.filter(workspace=OuterRef("pk"))))
     qs = qs.annotate(
         user_is_owner=Case(When(owner_id=user_id, then=Value(True)), default=Value(False), output_field=BooleanField())

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/serializers/nested.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/serializers/nested.py
@@ -8,7 +8,7 @@
 from taiga.base.serializers import UUIDB64, BaseModel
 
 
-class WorkspaceSummarySerializer(BaseModel):
+class WorkspaceNestedSerializer(BaseModel):
     id: UUIDB64
     name: str
     slug: str

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/serializers/services.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/serializers/services.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos Ventures SL
+
+from taiga.workspaces.workspaces.models import Workspace
+from taiga.workspaces.workspaces.serializers import WorkspaceDetailSerializer, WorkspaceSerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceNestedSerializer
+
+
+def serialize_workspace(workspace: Workspace, user_role: str, total_projects: str) -> WorkspaceSerializer:
+    return WorkspaceSerializer(
+        id=workspace.id,
+        name=workspace.name,
+        slug=workspace.slug,
+        color=workspace.color,
+        total_projects=total_projects,
+        has_projects=workspace.has_projects,  # type: ignore[attr-defined]
+        is_premium=workspace.is_premium,
+        user_role=user_role,
+        user_is_owner=workspace.user_is_owner,  # type: ignore[attr-defined]
+    )
+
+
+def serialize_workspace_detail(workspace: Workspace) -> WorkspaceDetailSerializer:
+    return WorkspaceDetailSerializer(
+        id=workspace.id,
+        name=workspace.name,
+        slug=workspace.slug,
+        color=workspace.color,
+        latest_projects=workspace.latest_projects,  # type: ignore[attr-defined]
+        invited_projects=workspace.invited_projects,  # type: ignore[attr-defined]
+        total_projects=workspace.total_projects,  # type: ignore[attr-defined]
+        has_projects=workspace.has_projects,  # type: ignore[attr-defined]
+        is_premium=workspace.is_premium,
+        user_role=workspace.user_role,  # type: ignore[attr-defined]
+        user_is_owner=workspace.user_is_owner,  # type: ignore[attr-defined]
+    )
+
+
+def serialize_nested(workspace: Workspace, user_role: str) -> WorkspaceNestedSerializer:
+    return WorkspaceNestedSerializer(
+        id=workspace.id,
+        name=workspace.name,
+        slug=workspace.slug,
+        user_role=user_role,
+        is_premium=workspace.is_premium,
+    )

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/services.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/services.py
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright (c) 2021-present Kaleidos Ventures SL
-
 from typing import cast
 from uuid import UUID
 
@@ -16,7 +15,9 @@ from taiga.workspaces.roles import repositories as ws_roles_repositories
 from taiga.workspaces.roles import services as ws_roles_services
 from taiga.workspaces.workspaces import repositories as workspaces_repositories
 from taiga.workspaces.workspaces.models import Workspace
-from taiga.workspaces.workspaces.serializers.related import WorkspaceSummarySerializer
+from taiga.workspaces.workspaces.serializers import WorkspaceDetailSerializer, WorkspaceSerializer
+from taiga.workspaces.workspaces.serializers import services as serializers_services
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceNestedSerializer
 
 ##########################################################
 # create workspace
@@ -41,8 +42,11 @@ async def create_workspace(name: str, color: int, owner: User) -> Workspace:
 ##########################################################
 
 
-async def list_user_workspaces(user: User) -> list[Workspace]:
-    return await workspaces_repositories.list_user_workspaces_overview(user=user)
+async def list_user_workspaces(user: User) -> list[WorkspaceDetailSerializer]:
+    return [
+        serializers_services.serialize_workspace_detail(workspace=workspace)
+        for workspace in await workspaces_repositories.list_user_workspaces_overview(user=user)
+    ]
 
 
 ##########################################################
@@ -54,21 +58,21 @@ async def get_workspace(id: UUID) -> Workspace | None:
     return await workspaces_repositories.get_workspace(filters={"id": id})
 
 
-async def get_workspace_detail(id: UUID, user_id: UUID | None) -> Workspace | None:
-    user_workspace_role_name = await ws_roles_services.get_workspace_role_name(workspace_id=id, user_id=user_id)
-    user_projects_count = await projects_repositories.get_total_projects(
-        filters={"workspace_id": id, "project_or_workspace_member_id": user_id},
-    )
-    return await workspaces_repositories.get_workspace_detail(
-        filters={"id": id},
-        user_id=user_id,
-        user_workspace_role_name=user_workspace_role_name,
-        user_projects_count=user_projects_count,
-    )
+async def get_workspace_detail(id: UUID, user_id: UUID | None) -> WorkspaceSerializer | None:
+    workspace = await workspaces_repositories.get_workspace_detail(filters={"id": id}, user_id=user_id)
+    if workspace:
+        return serializers_services.serialize_workspace(
+            workspace=workspace,
+            user_role=await ws_roles_services.get_workspace_role_name(workspace_id=id, user_id=user_id),
+            total_projects=await projects_repositories.get_total_projects(
+                filters={"workspace_id": id, "project_or_workspace_member_id": user_id}
+            ),
+        )
+
+    return None
 
 
-# TODO: change this name to `get_workspace_nested`
-async def get_workspace_summary(id: UUID, user_id: UUID | None) -> WorkspaceSummarySerializer:
+async def get_workspace_nested(id: UUID, user_id: UUID | None) -> WorkspaceNestedSerializer:
     # TODO: this service should be improved
     user_workspace_role_name = await ws_roles_services.get_workspace_role_name(workspace_id=id, user_id=user_id)
     workspace = cast(
@@ -77,15 +81,12 @@ async def get_workspace_summary(id: UUID, user_id: UUID | None) -> WorkspaceSumm
             filters={"id": id},
         ),
     )
-    # TODO: take this code to a workspaces/serializers/services.py
-    return WorkspaceSummarySerializer(
-        id=workspace.id,
-        name=workspace.name,
-        slug=workspace.slug,
-        user_role=user_workspace_role_name,
-        is_premium=workspace.is_premium,
-    )
+
+    return serializers_services.serialize_nested(workspace=workspace, user_role=user_workspace_role_name)
 
 
-async def get_user_workspace(user: User, id: UUID) -> Workspace | None:
-    return await workspaces_repositories.get_user_workspace_overview(user=user, id=id)
+async def get_user_workspace(user: User, id: UUID) -> WorkspaceDetailSerializer | None:
+    workspace = await workspaces_repositories.get_user_workspace_overview(user=user, id=id)
+    if workspace:
+        return serializers_services.serialize_workspace_detail(workspace=workspace)
+    return None

--- a/python/apps/taiga/tests/integration/taiga/workspaces/workspaces/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/workspaces/test_repositories.py
@@ -91,27 +91,19 @@ async def test_get_workspace_detail_premium_projects_ws_member():
     # assert workspace1 - user8
     res_ws = await repositories.get_workspace_detail(
         user_id=user8.id,
-        user_workspace_role_name="admin",
-        user_projects_count=7,
         filters={"id": workspace1.id},
     )
     assert res_ws == workspace1
-    assert res_ws.total_projects == 7
     assert res_ws.user_is_owner is True
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "admin"
     # assert workspace1 - user9
     res_ws = await repositories.get_workspace_detail(
         user_id=user9.id,
-        user_workspace_role_name="member",
-        user_projects_count=5,
         filters={"id": workspace1.id},
     )
     assert res_ws == workspace1
-    assert res_ws.total_projects == 5
     assert res_ws.user_is_owner is False
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "member"
 
 
 async def test_get_workspace_detail_premium_no_projects():
@@ -126,27 +118,19 @@ async def test_get_workspace_detail_premium_no_projects():
     # assert workspace3 - user10
     res_ws = await repositories.get_workspace_detail(
         user_id=user10.id,
-        user_workspace_role_name="admin",
-        user_projects_count=0,
         filters={"id": workspace3.id},
     )
     assert res_ws == workspace3
-    assert res_ws.total_projects == 0
     assert res_ws.user_is_owner is True
     assert res_ws.has_projects is False
-    assert res_ws.user_role == "admin"
     # assert workspace3 - user11
     res_ws = await repositories.get_workspace_detail(
         user_id=user11.id,
-        user_workspace_role_name="member",
-        user_projects_count=0,
         filters={"id": workspace3.id},
     )
     assert res_ws == workspace3
-    assert res_ws.total_projects == 0
     assert res_ws.user_is_owner is False
     assert res_ws.has_projects is False
-    assert res_ws.user_role == "member"
 
 
 async def test_get_workspace_detail_no_premium_no_projects():
@@ -156,15 +140,11 @@ async def test_get_workspace_detail_no_premium_no_projects():
     workspace4 = await f.create_workspace(name="workspace4", owner=user12, is_premium=False)
     res_ws = await repositories.get_workspace_detail(
         user_id=user12.id,
-        user_workspace_role_name="admin",
-        user_projects_count=0,
         filters={"id": workspace4.id},
     )
     assert res_ws == workspace4
-    assert res_ws.total_projects == 0
     assert res_ws.user_is_owner is True
     assert res_ws.has_projects is False
-    assert res_ws.user_role == "admin"
 
 
 async def test_get_workspace_detail_premium_projects_no_ws_member():
@@ -191,27 +171,19 @@ async def test_get_workspace_detail_premium_projects_no_ws_member():
     # assert workspace5 - user13
     res_ws = await repositories.get_workspace_detail(
         user_id=user13.id,
-        user_workspace_role_name="admin",
-        user_projects_count=4,
         filters={"id": workspace5.id},
     )
     assert res_ws == workspace5
-    assert res_ws.total_projects == 4
     assert res_ws.user_is_owner is True
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "admin"
     # assert workspace5 - user14
     res_ws = await repositories.get_workspace_detail(
         user_id=user14.id,
-        user_workspace_role_name="guest",
-        user_projects_count=3,
         filters={"id": workspace5.id},
     )
     assert res_ws == workspace5
-    assert res_ws.total_projects == 3
     assert res_ws.user_is_owner is False
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "guest"
 
 
 async def test_get_workspace_detail_premium_no_projects_no_ws_member():
@@ -226,27 +198,19 @@ async def test_get_workspace_detail_premium_no_projects_no_ws_member():
     # assert workspace6 - user15
     res_ws = await repositories.get_workspace_detail(
         user_id=user15.id,
-        user_workspace_role_name="admin",
-        user_projects_count=1,
         filters={"id": workspace6.id},
     )
     assert res_ws == workspace6
-    assert res_ws.total_projects == 1
     assert res_ws.user_is_owner is True
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "admin"
     # assert workspace6 - user16
     res_ws = await repositories.get_workspace_detail(
         user_id=user16.id,
-        user_workspace_role_name="none",
-        user_projects_count=0,
         filters={"id": workspace6.id},
     )
     assert res_ws == workspace6
-    assert res_ws.total_projects == 0
     assert res_ws.user_is_owner is False
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "none"
 
 
 async def test_get_workspace_detail_no_ws_members():
@@ -261,27 +225,19 @@ async def test_get_workspace_detail_no_ws_members():
     # assert workspace7 - user17
     res_ws = await repositories.get_workspace_detail(
         user_id=user17.id,
-        user_workspace_role_name="none",
-        user_projects_count=0,
         filters={"id": workspace7.id},
     )
     assert res_ws == workspace7
-    assert res_ws.total_projects == 0
     assert res_ws.user_is_owner is False
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "none"
     # assert workspace7 - user18
     res_ws = await repositories.get_workspace_detail(
         user_id=user18.id,
-        user_workspace_role_name="none",
-        user_projects_count=0,
         filters={"id": workspace7.id},
     )
     assert res_ws == workspace7
-    assert res_ws.total_projects == 0
     assert res_ws.user_is_owner is False
     assert res_ws.has_projects is True
-    assert res_ws.user_role == "none"
 
 
 ##########################################################

--- a/python/apps/taiga/tests/unit/taiga/base/api/test_responses.py
+++ b/python/apps/taiga/tests/unit/taiga/base/api/test_responses.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2021-present Kaleidos Ventures SL
+
+from taiga.base.api import responses
+from taiga.workspaces.workspaces.serializers import WorkspaceDetailSerializer
+
+
+def test_validate_200_response_ok(client):
+    result = responses.http_status_200(model=WorkspaceDetailSerializer)
+    assert result[200]["model"] == WorkspaceDetailSerializer

--- a/python/apps/taiga/tests/unit/taiga/projects/projects/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/projects/test_services.py
@@ -14,7 +14,7 @@ from taiga.projects.invitations.choices import ProjectInvitationStatus
 from taiga.projects.projects import services
 from taiga.projects.projects.services import exceptions as ex
 from taiga.users.models import AnonymousUser
-from taiga.workspaces.workspaces.serializers.related import WorkspaceSummarySerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceNestedSerializer
 from tests.utils import factories as f
 from tests.utils.images import valid_image_upload_file
 
@@ -174,7 +174,7 @@ async def test_get_project_detail():
         fake_permissions_services.get_user_workspace_role_info.return_value = (True, True, [])
         fake_permissions_services.get_user_permissions_for_project.return_value = []
         fake_permissions_services.has_pending_project_invitation.return_value = True
-        fake_workspaces_services.get_workspace_summary.return_value = WorkspaceSummarySerializer(
+        fake_workspaces_services.get_workspace_nested.return_value = WorkspaceNestedSerializer(
             id=uuid.uuid1(), name="ws 1", slug="ws-1", user_role="admin", is_premium=True
         )
         await services.get_project_detail(project=project, user=user)
@@ -191,7 +191,7 @@ async def test_get_project_detail():
             project=project,
         )
         fake_permissions_services.has_pending_project_invitation.assert_awaited_once_with(user=user, project=project)
-        fake_workspaces_services.get_workspace_summary.assert_awaited_once_with(id=workspace.id, user_id=user.id)
+        fake_workspaces_services.get_workspace_nested.assert_awaited_once_with(id=workspace.id, user_id=user.id)
 
 
 async def test_get_project_detail_anonymous():
@@ -208,7 +208,7 @@ async def test_get_project_detail_anonymous():
         fake_permissions_services.get_user_workspace_role_info.return_value = (True, True, [])
         fake_permissions_services.get_user_permissions_for_project.return_value = []
         fake_permissions_services.has_pending_project_invitation.return_value = False
-        fake_workspaces_services.get_workspace_summary.return_value = WorkspaceSummarySerializer(
+        fake_workspaces_services.get_workspace_nested.return_value = WorkspaceNestedSerializer(
             id=uuid.uuid1(), name="ws 1", slug="ws-1", user_role="admin", is_premium=True
         )
         await services.get_project_detail(project=project, user=user)
@@ -225,7 +225,7 @@ async def test_get_project_detail_anonymous():
             project=project,
         )
         fake_permissions_services.has_pending_project_invitation.assert_not_awaited()
-        fake_workspaces_services.get_workspace_summary.assert_awaited_once_with(id=workspace.id, user_id=user.id)
+        fake_workspaces_services.get_workspace_nested.assert_awaited_once_with(id=workspace.id, user_id=user.id)
 
 
 ##########################################################

--- a/python/apps/taiga/tests/unit/taiga/workspaces/workspaces/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/workspaces/workspaces/test_services.py
@@ -47,7 +47,9 @@ async def test_get_workspace():
 
 async def test_get_workspace_detail():
     user = await f.create_user()
-    workspace = await f.create_workspace(owner=user)
+    workspace = await f.create_workspace(name="test", owner=user)
+    workspace.has_projects = True
+    workspace.user_is_owner = True
 
     with (
         patch("taiga.workspaces.workspaces.services.workspaces_repositories", autospec=True) as fake_workspaces_repo,
@@ -56,21 +58,20 @@ async def test_get_workspace_detail():
     ):
         fake_ws_roles_services.get_workspace_role_name.return_value = "admin"
         fake_projects_repo.get_total_projects.return_value = 1
+        fake_workspaces_repo.get_workspace_detail.return_value = workspace
         await services.get_workspace_detail(id=workspace.id, user_id=user.id)
         fake_workspaces_repo.get_workspace_detail.assert_awaited_with(
             user_id=user.id,
-            user_workspace_role_name="admin",
-            user_projects_count=1,
             filters={"id": workspace.id},
         )
 
 
 ##########################################################
-# get_workspace_summary
+# get_workspace_nested
 ##########################################################
 
 
-async def test_get_workspace_summary():
+async def get_workspace_nestedy():
     user = await f.create_user()
     workspace = await f.create_workspace(owner=user)
 


### PR DESCRIPTION
This PR:
- deletes schemas from Workflows repositories in favor of custom serializers
- adds a new base method to model api responses (for openApi)
- changes the api to return serialized responses (when the object is not a plain ORM object)
- change sthe service to serialize the required previous responses
- partially extracts  (when possible) the new fields annotation logic from the repository to the service layer
- normalizes some names

![gif](https://media.giphy.com/media/Btn42lfKKrOzS/giphy.gif)


### What to test:

- [x] Review the code
- [x] Try to increase the typing strength of file `base.api.responses.py`
- [x] Tests are green

