### PR TITLE
feat(stories): u#226 t#3270 add user to delete_story event content

### DIFF
--- a/python/apps/taiga/src/taiga/stories/stories/api/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/api/__init__.py
@@ -208,7 +208,7 @@ async def delete_story(
     story = await get_story_or_404(project_id=project_id, ref=ref)
     await check_permissions(permissions=DELETE_STORY, user=request.user, obj=story)
 
-    await stories_services.delete_story(story=story)
+    await stories_services.delete_story(story=story, deleted_by=request.user)
 
 
 ################################################

--- a/python/apps/taiga/src/taiga/stories/stories/events/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/events/__init__.py
@@ -14,6 +14,7 @@ from taiga.stories.stories.events.content import (
     UpdateStoryContent,
 )
 from taiga.stories.stories.serializers import ReorderStoriesSerializer, StoryDetailSerializer
+from taiga.users.models import AnyUser
 
 CREATE_STORY = "stories.create"
 UPDATE_STORY = "stories.update"
@@ -50,12 +51,9 @@ async def emit_when_stories_are_reordered(project: Project, reorder: ReorderStor
     )
 
 
-async def emit_event_when_story_is_deleted(
-    project: Project,
-    ref: int,
-) -> None:
+async def emit_event_when_story_is_deleted(project: Project, ref: int, deleted_by: AnyUser) -> None:
     await events_manager.publish_on_project_channel(
         project=project,
         type=DELETE_STORY,
-        content=DeleteStoryContent(ref=ref),
+        content=DeleteStoryContent(ref=ref, deleted_by=deleted_by),
     )

--- a/python/apps/taiga/src/taiga/stories/stories/events/content.py
+++ b/python/apps/taiga/src/taiga/stories/stories/events/content.py
@@ -7,6 +7,7 @@
 
 from taiga.base.serializers import BaseModel
 from taiga.stories.stories.serializers import ReorderStoriesSerializer, StoryDetailSerializer
+from taiga.users.serializers.nested import UserNestedSerializer
 
 
 class CreateStoryContent(BaseModel):
@@ -24,3 +25,4 @@ class ReorderStoriesContent(BaseModel):
 
 class DeleteStoryContent(BaseModel):
     ref: int
+    deleted_by: UserNestedSerializer

--- a/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
@@ -17,7 +17,7 @@ from taiga.stories.stories.models import Story
 from taiga.stories.stories.serializers import ReorderStoriesSerializer, StoryDetailSerializer, StorySummarySerializer
 from taiga.stories.stories.serializers import services as serializers_services
 from taiga.stories.stories.services import exceptions as ex
-from taiga.users.models import User
+from taiga.users.models import AnyUser, User
 from taiga.workflows import repositories as workflows_repositories
 from taiga.workflows.models import Workflow, WorkflowStatus
 
@@ -303,10 +303,12 @@ async def reorder_stories(
 ##########################################################
 
 
-async def delete_story(story: Story) -> bool:
+async def delete_story(story: Story, deleted_by: AnyUser) -> bool:
     deleted = await stories_repositories.delete_stories(filters={"id": story.id})
     if deleted > 0:
-        await stories_events.emit_event_when_story_is_deleted(project=story.project, ref=story.ref)
+        await stories_events.emit_event_when_story_is_deleted(
+            project=story.project, ref=story.ref, deleted_by=deleted_by
+        )
         return True
 
     return False

--- a/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
@@ -533,6 +533,7 @@ async def test_reorder_story_not_all_stories_exist():
 
 
 async def test_delete_story_fail():
+    user = f.build_user()
     story = f.build_story()
 
     with (
@@ -541,7 +542,7 @@ async def test_delete_story_fail():
     ):
         fake_story_repo.delete_stories.return_value = 0
 
-        await services.delete_story(story=story)
+        await services.delete_story(story=story, deleted_by=user)
         fake_stories_events.emit_event_when_story_is_deleted.assert_not_awaited()
         fake_story_repo.delete_stories.assert_awaited_once_with(
             filters={"id": story.id},
@@ -549,6 +550,7 @@ async def test_delete_story_fail():
 
 
 async def test_delete_story_ok():
+    user = f.build_user()
     story = f.build_story()
 
     with (
@@ -557,9 +559,9 @@ async def test_delete_story_ok():
     ):
         fake_story_repo.delete_stories.return_value = 1
 
-        await services.delete_story(story=story)
+        await services.delete_story(story=story, deleted_by=user)
         fake_stories_events.emit_event_when_story_is_deleted.assert_awaited_once_with(
-            project=story.project, ref=story.ref
+            project=story.project, ref=story.ref, deleted_by=user
         )
         fake_story_repo.delete_stories.assert_awaited_once_with(
             filters={"id": story.id},

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -385,6 +385,7 @@ Content for:
   ```
   {
       "ref": "story ref (int)"
+      "deleted_by": {... basic user info ...}
   }
   ```
 


### PR DESCRIPTION
![](https://media.giphy.com/media/P7PmvHY6kzAqY/giphy.gif)

This PR only adds the information of who deleted the history to the event

## How to validate:

- [x] Review the code
- [x] Automatic tests are green
- [x] Manual test:
  - Try to delete an story with an api call and check the emitted events contains the attribute `deleted_by` with the user information.