### PR TITLE
fix: typo

### DIFF
--- a/javascript/apps/taiga/src/assets/i18n/ar.json
+++ b/javascript/apps/taiga/src/assets/i18n/ar.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/bg.json
+++ b/javascript/apps/taiga/src/assets/i18n/bg.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/ca.json
+++ b/javascript/apps/taiga/src/assets/i18n/ca.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/en-US.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",

--- a/javascript/apps/taiga/src/assets/i18n/es-ES.json
+++ b/javascript/apps/taiga/src/assets/i18n/es-ES.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/eu.json
+++ b/javascript/apps/taiga/src/assets/i18n/eu.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/fa.json
+++ b/javascript/apps/taiga/src/assets/i18n/fa.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/he.json
+++ b/javascript/apps/taiga/src/assets/i18n/he.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/ja.json
+++ b/javascript/apps/taiga/src/assets/i18n/ja.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/ko.json
+++ b/javascript/apps/taiga/src/assets/i18n/ko.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/pt-BR.json
+++ b/javascript/apps/taiga/src/assets/i18n/pt-BR.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/pt.json
+++ b/javascript/apps/taiga/src/assets/i18n/pt.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/ru.json
+++ b/javascript/apps/taiga/src/assets/i18n/ru.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/story/ar.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ar.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/bg.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/bg.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ca.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ca.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/es-ES.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/es-ES.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/eu.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/eu.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/fa.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/fa.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/he.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/he.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ja.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ja.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ko.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ko.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/pt-BR.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/pt-BR.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/pt.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/pt.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ru.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ru.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/uk.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/uk.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/zh-Hans.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/zh-Hans.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/zh-Hant.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/zh-Hant.json
@@ -20,5 +20,12 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
-  "status": "Status"
+  "status": "Status",
+  "delete": {
+    "delete_story": "Delete Story",
+    "confirm": "Are you sure you want to delete this story?",
+    "confirm_info": "All story information will be permanently deleted. There is no undo.",
+    "confirm_action": "Yes, delete.",
+    "cancel": "{{commons.cancel}}"
+  }
 }

--- a/javascript/apps/taiga/src/assets/i18n/uk.json
+++ b/javascript/apps/taiga/src/assets/i18n/uk.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/zh-Hans.json
+++ b/javascript/apps/taiga/src/assets/i18n/zh-Hans.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",

--- a/javascript/apps/taiga/src/assets/i18n/zh-Hant.json
+++ b/javascript/apps/taiga/src/assets/i18n/zh-Hant.json
@@ -99,7 +99,7 @@
     "public_permissions": "There was a problem loading public permissions",
     "workspace_permissions": "There was a problem loading workspace  permissions",
     "resend_email": "There was a problem reseind your email",
-    "save_changes": "An error ocurred while saving your changes",
+    "save_changes": "An error occurred while saving your changes",
     "generic_toast_label": "Something went wrong!",
     "generic_toast_message": "Try again in a few minutes.",
     "invalid_token_toast_message": "Invalid token.",
@@ -107,7 +107,9 @@
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
     "modify_story_permission": "You no longer have permissions to modify stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project"
+    "admin_permission": "You  are no longer admin on this project",
+    "entity_no_longer_exists": "This {{entity}} no longer exists",
+    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
   },
   "discard_changes": {
     "title": "Discard changes?",


### PR DESCRIPTION
This PR just fixes the typo and adds missing translations

From
```
"save_changes": "An error **ocurred** while saving your changes",
```

TO

```
"save_changes": "An error **occurred** while saving your changes",
```