### PR TITLE
fix(delete-story): delete/permissions redirects and error messages

### DIFF
--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/effects/kanban.effects.spec.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/effects/kanban.effects.spec.ts
@@ -30,6 +30,7 @@ import {
 } from '~/app/modules/project/data-access/+state/selectors/project.selectors';
 import { KanbanStoryA11y } from '~/app/modules/project/feature-kanban/kanban.model';
 import { AppService } from '~/app/services/app.service';
+import { getTranslocoModule } from '~/app/transloco/transloco-testing.module';
 import {
   KanbanActions,
   KanbanApiActions,
@@ -49,6 +50,7 @@ describe('ProjectEffects', () => {
       provideMockActions(() => actions$),
       provideMockStore({ initialState: {} }),
     ],
+    imports: [getTranslocoModule()],
     mocks: [ProjectApiService, AppService],
   });
 

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/effects/kanban.effects.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/effects/kanban.effects.ts
@@ -8,6 +8,7 @@
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { TranslocoService } from '@ngneat/transloco';
 import { Actions, concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { fetch, optimisticUpdate, pessimisticUpdate } from '@nrwl/angular';
@@ -256,7 +257,10 @@ export class KanbanEffects {
         filter((error) => error.errorStatus === 403),
         tap(() => {
           this.appService.toastNotification({
-            message: 'errors.modify_story_permission',
+            message: 'errors.lose_story_permission',
+            paramsMessage: {
+              permissions: this.translocoService.translate('commons.modify'),
+            },
             status: TuiNotification.Error,
           });
         })
@@ -330,6 +334,7 @@ export class KanbanEffects {
     private actions$: Actions,
     private store: Store,
     private projectApiService: ProjectApiService,
-    private kanbanScrollManagerService: KanbanScrollManagerService
+    private kanbanScrollManagerService: KanbanScrollManagerService,
+    private translocoService: TranslocoService
   ) {}
 }

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.spec.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.spec.ts
@@ -24,6 +24,7 @@ import { selectCurrentProject } from '~/app/modules/project/data-access/+state/s
 import { selectWorkflows } from '~/app/modules/project/feature-kanban/data-access/+state/selectors/kanban.selectors';
 import { AppService } from '~/app/services/app.service';
 import { LocalStorageService } from '~/app/shared/local-storage/local-storage.service';
+import { getTranslocoModule } from '~/app/transloco/transloco-testing.module';
 import {
   StoryDetailActions,
   StoryDetailApiActions,
@@ -45,7 +46,7 @@ describe('StoryDetailEffects', () => {
       provideMockActions(() => actions$),
       provideMockStore({ initialState: {} }),
     ],
-    imports: [],
+    imports: [getTranslocoModule()],
     mocks: [ProjectApiService, AppService, Router, LocalStorageService],
   });
 

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.ts
@@ -9,6 +9,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
+import { TranslocoService } from '@ngneat/transloco';
 import { Actions, concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { fetch, pessimisticUpdate } from '@nrwl/angular';
@@ -128,7 +129,10 @@ export class StoryDetailEffects {
         onError: (action, httpResponse: HttpErrorResponse) => {
           if (httpResponse.status === 403) {
             this.appService.toastNotification({
-              message: 'errors.modify_story_permission',
+              message: 'errors.lose_story_permissions',
+              paramsMessage: {
+                permission: this.translocoService.translate('commons.modify'),
+              },
               status: TuiNotification.Error,
             });
           } else {
@@ -254,6 +258,7 @@ export class StoryDetailEffects {
     private router: Router,
     private actions$: Actions,
     private projectApiService: ProjectApiService,
-    private appService: AppService
+    private appService: AppService,
+    private translocoService: TranslocoService
   ) {}
 }

--- a/javascript/apps/taiga/src/assets/i18n/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/en-US.json
@@ -36,7 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
-    "next_page": "Next page"
+    "next_page": "Next page",
+    "modify": "modify",
+    "delete": "delete"
   },
   "navigation": {
     "go_home": "Go to home",
@@ -106,7 +108,7 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
     "admin_permission": "You  are no longer admin on this project"
   },


### PR DESCRIPTION
How to test

1. If a user lose **deleting permissions** after they've started the delete action and before confirming: The story closes and a toast appears about the loss of deleting permissions. The message clearly says that delete permissions have been lost.
2. f someone has a story open and another person deletes it: The story disappears immediately. A toast appears informing about it. 