### PR TITLE
feat(story): u#3134 edit title

### DIFF
--- a/javascript/apps/taiga-e2e/src/e2e/edit-project.cy.ts
+++ b/javascript/apps/taiga-e2e/src/e2e/edit-project.cy.ts
@@ -53,7 +53,7 @@ describe('edit project', () => {
     fillEditProject(project.name, null);
 
     cy.getBySel('cancel-edit-project').click();
-    cy.getBySel('submit-confirm-edit-project').click();
+    cy.getBySel('confirm-edit').click();
 
     cy.getBySel('project-name').should('not.contain', project.name);
   });

--- a/javascript/apps/taiga/src/app/modules/project/components/field-conflict/field-conflict.component.css
+++ b/javascript/apps/taiga/src/app/modules/project/components/field-conflict/field-conflict.component.css
@@ -1,0 +1,80 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2021-present Kaleidos Ventures SL
+*/
+
+:host {
+  background: var(--color-white);
+  border-radius: 4px;
+  box-shadow: 0 4px 8px -2px rgba(23, 28, 36, 0.25),
+    0 0 1px rgba(23, 28, 36, 0.31);
+  display: block;
+  padding: var(--spacing-16);
+}
+
+.title {
+  background-color: var(--color-warning20);
+  border: 1px solid var(--color-warning30);
+  border-radius: 4px;
+  color: var(--color-warning80);
+  display: flex;
+  font-weight: var(--font-weight-medium);
+  margin-block-end: var(--spacing-16);
+  padding: var(--spacing-8);
+
+  & tui-svg {
+    margin-block-start: 2px;
+  }
+}
+
+.copy-title {
+  color: var(--color-gray100);
+  font-weight: var(--font-weight-medium);
+  margin-block-end: var(--spacing-8);
+}
+
+.alert-icon {
+  block-size: 13px;
+  color: var(--color-warning50);
+}
+
+.description {
+  margin-inline: auto;
+  max-inline-size: 520px;
+}
+
+.copy-description,
+.description {
+  color: var(--color-gray80);
+  margin-block-end: var(--spacing-8);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  & button {
+    margin-block-start: var(--spacing-8);
+
+    &:last-child {
+      margin-inline-start: var(--spacing-16);
+    }
+  }
+}
+
+.copy-link {
+  &.copied {
+    &::ng-deep .t-wrapper {
+      background-color: var(--color-ok10);
+      color: var(--color-ok80);
+    }
+
+    &::ng-deep svg {
+      fill: var(--color-ok60);
+    }
+  }
+}

--- a/javascript/apps/taiga/src/app/modules/project/components/field-conflict/field-conflict.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/components/field-conflict/field-conflict.component.html
@@ -1,0 +1,87 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2021-present Kaleidos Ventures SL
+-->
+
+<ng-container
+  *transloco="let t"
+  tgShortcut="conflict.close"
+  (tgShortcutAction)="cancel.next()">
+  <div (tgOutsideClick)="cancel.next()">
+    <ng-container *ngIf="!copyView">
+      <p
+        class="title"
+        tgAutoFocus
+        tabindex="-1">
+        <tui-svg
+          class="alert-icon"
+          src="alert"></tui-svg>
+        {{ t('field_conflict.title') }}
+      </p>
+      <p
+        class="description"
+        [innerHtml]="
+          t('field_conflict.description', { user: username, fieldName: field })
+        "></p>
+      <div class="actions">
+        <button
+          class="copy-link"
+          tuiButton
+          appearance="tertiary"
+          [class.copied]="copied"
+          [icon]="copied ? 'check' : 'duplicate'"
+          [cdkCopyToClipboard]="copyValue"
+          (click)="copy()">
+          <ng-container *ngIf="copied">
+            {{ t('field_conflict.copied') }}
+          </ng-container>
+          <ng-container *ngIf="!copied">
+            {{ t('field_conflict.copy') }}
+          </ng-container>
+        </button>
+        <button
+          tuiButton
+          appearance="primary"
+          (click)="acceptNewVersion()">
+          {{ t('field_conflict.see_new_version') }}
+        </button>
+      </div>
+    </ng-container>
+    <ng-container *ngIf="copyView">
+      <p
+        class="copy-title"
+        tgAutoFocus
+        tabindex="-1">
+        {{ t('field_conflict.copy_title') }}
+      </p>
+      <p class="copy-description">{{ t('field_conflict.copy_descripcion') }}</p>
+      <div class="actions">
+        <button
+          type="button"
+          (click)="accept.next()"
+          data-test="cancel-edit"
+          tuiLink>
+          {{ t('field_conflict.dismiss') }}
+        </button>
+        <button
+          class="copy-link"
+          tuiButton
+          appearance="primary"
+          [class.copied]="copied"
+          [icon]="copied ? 'check' : 'duplicate'"
+          [cdkCopyToClipboard]="copyValue"
+          (click)="copyAfterAccept()">
+          <ng-container *ngIf="copied">
+            {{ t('field_conflict.copied') }}
+          </ng-container>
+          <ng-container *ngIf="!copied">
+            {{ t('field_conflict.copy') }}
+          </ng-container>
+        </button>
+      </div>
+    </ng-container>
+  </div>
+</ng-container>

--- a/javascript/apps/taiga/src/app/modules/project/components/field-conflict/field-conflict.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/components/field-conflict/field-conflict.component.ts
@@ -1,0 +1,77 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { ClipboardModule } from '@angular/cdk/clipboard';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { TuiLinkModule, TuiSvgModule } from '@taiga-ui/core';
+import { CommonTemplateModule } from '~/app/shared/common-template.module';
+import { AutoFocusDirective } from '~/app/shared/directives/auto-focus/auto-focus.directive';
+import { OutsideClickDirective } from '~/app/shared/directives/outside-click/outside-click.directive';
+import { ShortcutDirective } from '~/app/shared/directives/shorcut/shorcut.directive';
+
+@Component({
+  selector: 'tg-field-conflict',
+  standalone: true,
+  imports: [
+    CommonTemplateModule,
+    TuiSvgModule,
+    ClipboardModule,
+    ShortcutDirective,
+    AutoFocusDirective,
+    OutsideClickDirective,
+    TuiLinkModule,
+  ],
+  templateUrl: './field-conflict.component.html',
+  styleUrls: ['./field-conflict.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FieldConflictComponent {
+  @Input()
+  public username!: string;
+
+  @Input()
+  public field!: string;
+
+  @Input()
+  public copyValue!: string;
+
+  @Output()
+  public cancel = new EventEmitter<void>();
+
+  @Output()
+  public accept = new EventEmitter<void>();
+
+  public copied = false;
+  public copyView = false;
+
+  public acceptNewVersion() {
+    if (this.copied) {
+      this.accept.emit();
+    } else {
+      this.copyView = true;
+    }
+  }
+
+  public copy() {
+    this.copied = true;
+  }
+
+  public copyAfterAccept() {
+    this.copy();
+
+    setTimeout(() => {
+      this.accept.next();
+    }, 2000);
+  }
+}

--- a/javascript/apps/taiga/src/app/modules/project/data-access/+state/actions/project.actions.ts
+++ b/javascript/apps/taiga/src/app/modules/project/data-access/+state/actions/project.actions.ts
@@ -7,7 +7,7 @@
  */
 
 import { createAction, createActionGroup, props } from '@ngrx/store';
-import { Membership, Project, Story } from '@taiga/data';
+import { Membership, Project, Story, StoryDetail } from '@taiga/data';
 
 export const fetchProjectSuccess = createAction(
   '[Project] fetch success',
@@ -60,7 +60,7 @@ export const newProjectMembers = createAction(
 );
 
 export const projectEventActions = createActionGroup({
-  source: 'Project',
+  source: 'Project ws',
   events: {
     'Unassigned Member Event': props<{
       storyRef: Story['ref'];
@@ -70,6 +70,6 @@ export const projectEventActions = createActionGroup({
       storyRef: Story['ref'];
       member: Membership['user'];
     }>(),
-    'Update Story': props<{ story: Story }>(),
+    'Update Story': props<{ story: StoryDetail }>(),
   },
 });

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/create-story-inline/kanban-create-story-inline.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/create-story-inline/kanban-create-story-inline.component.html
@@ -14,20 +14,22 @@ Copyright (c) 2021-present Kaleidos Ventures SL
     (submit)="submit()"
     #createstoryForm="ngForm">
     <tg-ui-input
-      [accessibleLabel]="t('kanban.create_story_form.story_title_label')">
+      [accessibleLabel]="t('common_story.create_story_form.story_title_label')">
       <input
         formControlName="title"
         data-test="story-title"
         #title
         inputRef
         [maxlength]="maxLength"
-        [placeholder]="t('kanban.create_story_form.story_title_placeholder')" />
+        [placeholder]="
+          t('common_story.create_story_form.story_title_placeholder')
+        " />
       <ng-container inputError>
         <tg-ui-error error="required">{{
-          t('kanban.create_story_form.title_story_required')
+          t('common_story.create_story_form.title_story_required')
         }}</tg-ui-error>
         <tg-ui-error error="pattern">{{
-          t('kanban.create_story_form.title_story_required')
+          t('common_story.create_story_form.title_story_required')
         }}</tg-ui-error>
       </ng-container>
     </tg-ui-input>
@@ -35,7 +37,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
       *ngIf="form.get('title')!.value?.length === maxLength"
       aria-live="assertive"
       class="max-length">
-      {{ t('kanban.create_story_form.max_length') }}
+      {{ t('common_story.create_story_form.max_length') }}
     </div>
     <div class="actions">
       <button
@@ -43,7 +45,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
         data-test="story-create"
         appearance="primary"
         type="submit">
-        {{ t('kanban.create_story_form.create_story_button') }}
+        {{ t('common_story.create_story_form.create_story_button') }}
       </button>
 
       <button

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/create-story-inline/kanban-create-story-inline.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/create-story-inline/kanban-create-story-inline.component.ts
@@ -18,12 +18,16 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import { FormBuilder, Validators } from '@angular/forms';
+import { FormBuilder } from '@angular/forms';
 import { TranslocoService } from '@ngneat/transloco';
 import { Store } from '@ngrx/store';
 import { Status, Workflow } from '@taiga/data';
 import { v4 } from 'uuid';
 import { KanbanActions } from '~/app/modules/project/feature-kanban/data-access/+state/actions/kanban.actions';
+import {
+  StoryTitleMaxLength,
+  StoryTitleValidation,
+} from '~/app/shared/story/title-validation';
 
 @Component({
   selector: 'tg-create-story-inline',
@@ -51,17 +55,10 @@ export class KanbanCreateStoryInlineComponent implements AfterViewInit {
     this.cancelSubmit();
   }
 
-  public maxLength = 500;
+  public maxLength = StoryTitleMaxLength;
 
   public form = this.fb.nonNullable.group({
-    title: [
-      '',
-      [
-        Validators.required,
-        Validators.maxLength(this.maxLength),
-        Validators.pattern(/^(\s+\S+\s*)*(?!\s).*$/),
-      ],
-    ],
+    title: ['', StoryTitleValidation],
   });
 
   public submitted = false;

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/reducers/kanban.reducer.spec.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/reducers/kanban.reducer.spec.ts
@@ -9,6 +9,7 @@
 import { randUuid } from '@ngneat/falso';
 import {
   StatusMockFactory,
+  StoryDetailMockFactory,
   StoryMockFactory,
   WorkflowMockFactory,
 } from '@taiga/data';
@@ -467,7 +468,7 @@ describe('Kanban reducer', () => {
     const workflow = WorkflowMockFactory();
     const status = StatusMockFactory();
     const status2 = StatusMockFactory();
-    const story = StoryMockFactory([status]);
+    const story = StoryDetailMockFactory([status]);
 
     workflow.statuses = [status, status2];
 
@@ -521,7 +522,7 @@ describe('Kanban reducer', () => {
     const workflow = WorkflowMockFactory();
     const status = StatusMockFactory();
     const status2 = StatusMockFactory();
-    const story = StoryMockFactory([status]);
+    const story = StoryDetailMockFactory([status]);
 
     workflow.statuses = [status, status2];
 

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/reducers/kanban.reducer.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/data-access/+state/reducers/kanban.reducer.ts
@@ -16,6 +16,7 @@ import {
 } from '~/app/modules/project/feature-kanban/kanban.model';
 import { StoryDetailActions } from '~/app/modules/project/story-detail/data-access/+state/actions/story-detail.actions';
 import { DropCandidate } from '~/app/shared/drag/drag.model';
+import { pick } from '~/app/shared/utils/pick';
 import { immerReducer } from '~/app/shared/utils/store';
 import {
   KanbanActions,
@@ -550,6 +551,17 @@ export const reducer = createReducer(
         });
       }
     }
+
+    state = replaceStory(state, (it) => {
+      if (it.ref === story.ref) {
+        return {
+          ...it,
+          ...pick(story, ['title']),
+        };
+      }
+
+      return it;
+    });
 
     return state;
   }),

--- a/javascript/apps/taiga/src/app/modules/project/feature-overview/components/edit-project/edit-project.component.css
+++ b/javascript/apps/taiga/src/app/modules/project/feature-overview/components/edit-project/edit-project.component.css
@@ -25,7 +25,3 @@ Copyright (c) 2021-present Kaleidos Ventures SL
   flex-direction: column;
   gap: var(--spacing-24);
 }
-
-.confirm-close-description {
-  margin-block-end: var(--spacing-32);
-}

--- a/javascript/apps/taiga/src/app/modules/project/feature-overview/components/edit-project/edit-project.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/feature-overview/components/edit-project/edit-project.component.html
@@ -90,31 +90,8 @@ Copyright (c) 2021-present Kaleidos Ventures SL
     </form>
   </tg-ui-modal>
 
-  <tg-ui-modal
-    class="confirm-close"
+  <tg-discard-changes-modal
     [open]="showConfirmEditProjectModal"
-    [width]="500"
-    (requestClose)="discard()">
-    <h1 class="title">{{ t('discard_changes.title') }}</h1>
-    <p class="confirm-close-description">
-      {{ t('discard_changes.description') }}
-    </p>
-    <div class="actions">
-      <button
-        type="button"
-        (click)="keepEditing()"
-        data-test="cancel-confirm-edit-project"
-        tuiLink>
-        {{ t('discard_changes.cancel') }}
-      </button>
-      <button
-        (click)="discard()"
-        data-test="submit-confirm-edit-project"
-        tuiButton
-        type="button"
-        appearance="primary">
-        {{ t('discard_changes.confirm') }}
-      </button>
-    </div>
-  </tg-ui-modal>
+    (discard)="discard()"
+    (cancel)="keepEditing()"></tg-discard-changes-modal>
 </ng-container>

--- a/javascript/apps/taiga/src/app/modules/project/feature-overview/components/edit-project/edit-project.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-overview/components/edit-project/edit-project.component.ts
@@ -29,6 +29,7 @@ import {
 import { AppService } from '~/app/services/app.service';
 import { ModalModule } from '@taiga/ui/modal';
 import { TuiAutoFocusModule } from '@taiga-ui/cdk';
+import { DiscardChangesModalComponent } from '~/app/shared/discard-changes-modal/discard-changes-modal.component';
 
 @Component({
   selector: 'tg-edit-project',
@@ -46,6 +47,7 @@ import { TuiAutoFocusModule } from '@taiga-ui/cdk';
     TuiLinkModule,
     ModalModule,
     TuiAutoFocusModule,
+    DiscardChangesModalComponent,
   ],
 })
 export class EditProjectComponent implements OnInit {
@@ -123,8 +125,6 @@ export class EditProjectComponent implements OnInit {
       if (data.logo === null) {
         delete data.logo;
       }
-
-      console.log(data);
 
       this.submitProject.next(data as EditProject);
     }

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-title/story-detail-title.component.css
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-title/story-detail-title.component.css
@@ -1,0 +1,111 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2021-present Kaleidos Ventures SL
+*/
+
+@import "tools/typography.css";
+
+:host {
+  display: block;
+  margin-block-end: var(--spacing-20);
+  padding: var(--spacing-8);
+
+  &.conflict {
+    background: repeating-linear-gradient(
+      -45deg,
+      #e2e6ee,
+      #e2e6ee 2px,
+      #eff0f5 2px,
+      #eff0f5 10px
+    );
+    border: 2px solid var(--color-gray40);
+    border-radius: 3px;
+    opacity: 0.8;
+  }
+
+  &:not(.conflict) {
+    & .title-wrapper {
+      cursor: pointer;
+    }
+  }
+
+  &:not(.edit) {
+    &:hover {
+      background-color: var(--color-gray20);
+    }
+  }
+}
+
+.title-wrapper {
+  position: relative;
+}
+
+.title {
+  @mixin font-heading-3;
+
+  margin: 0;
+}
+
+.edit-title {
+  inset-block-start: -4px;
+  inset-inline-end: -4px;
+  position: absolute;
+}
+
+.edit-title-field {
+  margin-block-end: var(--spacing-20);
+  position: relative;
+}
+
+.edit-field-actions {
+  display: flex;
+  gap: var(--spacing-8);
+  inset-block-end: var(--spacing-8);
+  inset-inline-end: var(--spacing-8);
+  position: absolute;
+}
+
+.shape-outside-text {
+  block-size: 32px;
+  inline-size: 32px;
+  shape-outside: inset(0 0 0 0);
+}
+
+.max-length {
+  @mixin font-small;
+
+  color: var(--color-gray80);
+  display: block;
+  padding-inline-start: var(--spacing-4);
+}
+
+tg-ui-textarea {
+  &::ng-deep {
+    & .t-counter {
+      display: none;
+    }
+
+    & .input-container {
+      position: relative;
+    }
+
+    /* stylelint-disable-next-line selector-max-type */
+    & label.t-content {
+      padding-block-end: var(--spacing-40);
+    }
+  }
+}
+
+tui-text-area {
+  /* stylelint-disable-next-line declaration-no-important */
+  --tui-textarea-height: var(--spacing-24) !important;
+
+  font-size: var(--font-size-heading-3);
+}
+
+tg-field-conflict {
+  margin-block-start: var(--spacing-8);
+}

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-title/story-detail-title.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-title/story-detail-title.component.html
@@ -1,0 +1,103 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2021-present Kaleidos Ventures SL
+-->
+
+<ng-container *transloco="let t">
+  <ng-container *ngIf="model$ | async as vm">
+    <div
+      *ngIf="!vm.conflict && !vm.edit"
+      class="title-wrapper"
+      (click)="editTitle()">
+      <div class="shape-outside-text float-inline-end"></div>
+      <h1 class="title">{{ vm.story.title }}</h1>
+      <button
+        *ngIf="!vm.conflict"
+        tgRestoreFocusTarget="edit-title"
+        (click)="editTitle()"
+        class="edit-title"
+        [attr.aria-label]="t('story.edit_title')"
+        appearance="tertiary"
+        tuiIconButton
+        icon="pen"
+        type="button"></button>
+    </div>
+    <div
+      *ngIf="vm.conflict"
+      tgRestoreFocus="edit-title"
+      class="title-wrapper">
+      <div class="shape-outside-text float-inline-end"></div>
+      <h1 class="title">{{ titleForm.get('title')!.value }}</h1>
+      <tg-field-conflict
+        *ngIf="vm.conflict"
+        [username]="vm.story.titleUpdatedBy.fullName"
+        [field]="t('field_conflict.fields.title')"
+        [copyValue]="titleForm.get('title')!.value"
+        (cancel)="cancelConflict()"
+        (accept)="acceptConflict()"></tg-field-conflict>
+    </div>
+    <div
+      *ngIf="vm.edit && !vm.conflict"
+      class="edit-title-field"
+      tgRestoreFocus="edit-title"
+      [tgRestoreFocusActive]="!vm.conflict">
+      <form
+        #formTpl="ngForm"
+        [formGroup]="titleForm"
+        [showFormErrors]="formTpl.submitted"
+        (ngSubmit)="save()">
+        <tg-ui-textarea>
+          <tui-text-area
+            class="general-textarea"
+            (keydown.code.enter)="onEnter($event)"
+            tgAutoFocus
+            formControlName="title"
+            [maxLength]="maxLength"
+            [expandable]="true"
+            [tuiTextfieldLabelOutside]="true"
+            (focusedChange)="focusChange.next($event)">
+          </tui-text-area>
+
+          <div class="edit-field-actions">
+            <button
+              (click)="cancelEditTitle()"
+              tuiButton
+              type="button"
+              appearance="tertiary">
+              {{ t('commons.cancel') }}
+            </button>
+            <button
+              tuiButton
+              type="submit"
+              appearance="primary">
+              {{ t('commons.save') }}
+            </button>
+          </div>
+
+          <ng-container inputError>
+            <tg-ui-error error="required">{{
+              t('common_story.create_story_form.title_story_required')
+            }}</tg-ui-error>
+            <tg-ui-error error="pattern">{{
+              t('common_story.create_story_form.title_story_required')
+            }}</tg-ui-error>
+
+            <div
+              *ngIf="(titleForm.get('title')!.value?.length ?? 0) >= maxLength"
+              aria-live="assertive"
+              class="max-length">
+              {{ t('common_story.create_story_form.max_length') }}
+            </div>
+          </ng-container>
+        </tg-ui-textarea>
+      </form>
+      <tg-discard-changes-modal
+        [open]="showConfirmEditTitleModal"
+        (discard)="discard()"
+        (cancel)="keepEditing()"></tg-discard-changes-modal>
+    </div>
+  </ng-container>
+</ng-container>

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-title/story-detail-title.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-title/story-detail-title.component.ts
@@ -1,0 +1,202 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  HostBinding,
+  HostListener,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { RxState } from '@rx-angular/state';
+import { ShortcutsService } from '@taiga/core';
+import { StoryDetailForm } from '~/app/modules/project/story-detail/story-detail.component';
+import {
+  StoryTitleMaxLength,
+  StoryTitleValidation,
+} from '~/app/shared/story/title-validation';
+import {
+  HasChanges,
+  HasChangesService,
+} from '~/app/shared/utils/has-changes.service';
+import { StoryDetail } from '@taiga/data';
+
+export interface StoryDetailTitleState {
+  story: StoryDetail;
+  editedStory: StoryDetail;
+  conflict: boolean;
+  edit: boolean;
+}
+
+@UntilDestroy()
+@Component({
+  selector: 'tg-story-detail-title',
+  templateUrl: './story-detail-title.component.html',
+  styleUrls: ['./story-detail-title.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [RxState],
+})
+export class StoryDetailTitleComponent implements OnChanges, HasChanges {
+  @Input()
+  public form!: FormGroup<StoryDetailForm>;
+
+  @Output()
+  public editChange = new EventEmitter<boolean>();
+
+  @Output()
+  public focusChange = new EventEmitter<boolean>();
+
+  @HostBinding('class.conflict')
+  public get conflict() {
+    return this.state.get('conflict');
+  }
+
+  @HostBinding('class.edit')
+  public get edit() {
+    return this.state.get('edit');
+  }
+
+  @Input()
+  public set story(story: StoryDetail) {
+    this.state.set({ story });
+  }
+
+  @HostListener('window:beforeunload')
+  public unloadHandler() {
+    return !this.hasChanges();
+  }
+
+  public titleForm = new FormGroup({
+    title: new FormControl('', {
+      nonNullable: true,
+      validators: StoryTitleValidation,
+    }),
+  });
+
+  public model$ = this.state.select();
+  public showConfirmEditTitleModal = false;
+  public maxLength = StoryTitleMaxLength;
+
+  constructor(
+    private hasChangesService: HasChangesService,
+    private state: RxState<StoryDetailTitleState>,
+    private shortcutsService: ShortcutsService,
+    private cd: ChangeDetectorRef
+  ) {
+    this.hasChangesService.addComponent(this);
+
+    this.shortcutsService
+      .task('edit-field.close')
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.cancelEditTitle();
+        this.cd.detectChanges();
+      });
+  }
+
+  public editTitle() {
+    this.reset();
+
+    this.state.set({ editedStory: this.state.get('story') });
+
+    this.setEdit(true);
+  }
+
+  public cancelEditTitle() {
+    if (this.hasChanges()) {
+      this.showConfirmEditTitleModal = true;
+    } else {
+      this.setEdit(false);
+    }
+  }
+
+  public save() {
+    const newVersion =
+      this.state.get('story').version !== this.state.get('editedStory').version;
+
+    if (newVersion && this.hasChanges()) {
+      this.setConflict(true);
+    } else if (this.titleForm.valid) {
+      this.setEdit(false);
+      this.form.get('title')?.setValue(this.titleForm.get('title')!.value);
+    }
+  }
+
+  public discard() {
+    this.showConfirmEditTitleModal = false;
+
+    this.reset();
+    this.setEdit(false);
+  }
+
+  public keepEditing() {
+    this.showConfirmEditTitleModal = false;
+  }
+
+  public onEnter(event: Event) {
+    event.preventDefault();
+    this.save();
+  }
+
+  public setConflict(conflict: boolean) {
+    const oldConflict = this.state.get('conflict');
+
+    if (oldConflict !== conflict) {
+      this.state.set({ conflict });
+
+      this.focusChange.next(conflict);
+    }
+  }
+
+  public hasChanges() {
+    return this.state.get('story').title !== this.titleForm.get('title')!.value;
+  }
+
+  public cancelConflict() {
+    this.setConflict(false);
+    this.setEdit(false);
+  }
+
+  public acceptConflict() {
+    this.setConflict(false);
+    this.setEdit(false);
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.form) {
+      this.titleForm
+        .get('title')!
+        .setValue(this.form.get('title')?.value ?? '');
+    }
+  }
+
+  private reset() {
+    this.setConflict(false);
+    this.titleForm.get('title')!.setValue(this.form.get('title')!.value ?? '');
+  }
+
+  private setEdit(edit: boolean) {
+    this.state.set({ edit });
+
+    this.editChange.next(edit);
+
+    if (edit) {
+      this.shortcutsService.setScope('edit-field');
+    } else {
+      this.shortcutsService.undoScope('edit-field');
+      this.focusChange.next(false);
+    }
+  }
+}

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/actions/story-detail.actions.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/actions/story-detail.actions.ts
@@ -63,14 +63,3 @@ export const StoryDetailApiActions = createActionGroup({
     'UnAssign Member Success': emptyProps(),
   },
 });
-
-export const StoryDetailEventsActions = createActionGroup({
-  source: 'StoryDetail Event',
-  events: {
-    'Update Story': props<{ story: StoryDetail }>(),
-    'Update Story Status By Reorder': props<{
-      status: StoryDetail['status'];
-    }>(),
-    'Assigned Member Event': props<{ story: StoryDetail }>(),
-  },
-});

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/reducers/story-detail.reducer.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/reducers/story-detail.reducer.ts
@@ -19,7 +19,6 @@ import { immerReducer } from '~/app/shared/utils/store';
 import {
   StoryDetailActions,
   StoryDetailApiActions,
-  StoryDetailEventsActions,
 } from '../actions/story-detail.actions';
 
 export interface StoryDetailState {
@@ -84,29 +83,16 @@ export const reducer = createReducer(
       return state;
     }
   ),
-  on(
-    StoryDetailEventsActions.updateStory,
-    (state, { story }): StoryDetailState => {
-      state.story = story;
+  on(projectEventActions.updateStory, (state, { story }): StoryDetailState => {
+    state.story = story;
 
-      return state;
-    }
-  ),
+    return state;
+  }),
   on(
     KanbanApiActions.moveStorySuccess,
     (state, { reorder }): StoryDetailState => {
       if (state.story && reorder.stories.includes(state.story.ref)) {
         state.story.status = reorder.status;
-      }
-
-      return state;
-    }
-  ),
-  on(
-    StoryDetailEventsActions.updateStoryStatusByReorder,
-    (state, action): StoryDetailState => {
-      if (state.story) {
-        state.story.status = action.status;
       }
 
       return state;

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.component.css
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.component.css
@@ -136,13 +136,12 @@ Copyright (c) 2021-present Kaleidos Ventures SL
 
 .main-content {
   margin-block: var(--spacing-16);
-  margin-inline: var(--spacing-24);
-}
+  margin-inline: var(--spacing-16) var(--spacing-24);
 
-.title {
-  @mixin font-heading-3;
-
-  margin-block: 0 var(--spacing-16);
+  & tg-story-detail-status,
+  & tg-story-detail-assign {
+    padding-inline-start: var(--spacing-16);
+  }
 }
 
 .creation-info {
@@ -150,6 +149,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
   display: flex;
   gap: var(--spacing-4);
   margin-block-end: var(--spacing-12);
+  padding-inline-start: var(--spacing-8);
 }
 
 .creation-info-fullname {
@@ -282,3 +282,25 @@ Copyright (c) 2021-present Kaleidos Ventures SL
   gap: var(--spacing-16);
   justify-content: flex-end;
 }
+
+.field-focus {
+  background-color: var(--color-gray20);
+}
+
+/* stylelint-disable selector-max-compound-selectors, selector-max-type */
+.field-edit {
+  & tg-story-detail-status,
+  & tg-story-detail-assign {
+    &::ng-deep {
+      & tui-select .tui-autofill {
+        background: var(--color-gray20);
+      }
+
+      & button .t-wrapper {
+        background: var(--color-gray20);
+        transition: none;
+      }
+    }
+  }
+}
+/* stylelint-enable selector-max-compound-selectors, selector-max-type */

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.component.html
@@ -6,7 +6,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 Copyright (c) 2021-present Kaleidos Ventures SL
 -->
 
-<ng-container *transloco="let t; read: 'story'">
+<ng-container *transloco="let t">
   <ng-container *ngIf="model$ | async as vm">
     <form
       *ngIf="form"
@@ -26,21 +26,23 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               #storyRef
               tabindex="0"
               [attr.aria-label]="
-                t('story_sr', {
+                t('story.story_sr', {
                   storyRef: vm.story.ref,
                   storyTitle: vm.story.title
                 })
               "
               class="story-ref story-detail-focus"
-              [innerHtml]="t('story', { storyRef: vm.story.ref })"></span>
+              [innerHtml]="t('story.story', { storyRef: vm.story.ref })"></span>
             <button
-              [attr.aria-label]="t('copy_story')"
+              [attr.aria-label]="t('story.copy_story')"
               [icon]="linkCopied ? 'check' : 'link'"
               appearance="tertiary"
               [class.copied]="linkCopied"
               class="copy-link"
               tuiIconButton
-              [tuiHint]="linkCopied ? t('link_copied') : t('click_to_copy')"
+              [tuiHint]="
+                linkCopied ? t('story.link_copied') : t('story.click_to_copy')
+              "
               [tuiHintManual]="hintShown"
               type="button"
               (click)="getStoryLink()"
@@ -57,7 +59,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               [disabled]="!vm.story.prev"
               [attr.aria-label]="
                 vm.story.prev
-                  ? t('previous_story', {
+                  ? t('story.previous_story', {
                       story: vm.story.prev!.title
                     })
                   : null
@@ -67,7 +69,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               class="chevron"
               tuiIconButton
               tuiHintDirection="top-right"
-              [tuiHint]="t('previous')"
+              [tuiHint]="t('story.previous')"
               (click)="navigateToPreviousStory(vm.story.prev!.ref)"
               type="button"></button>
             <button
@@ -75,7 +77,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               [disabled]="!vm.story.next"
               [attr.aria-label]="
                 vm.story.next
-                  ? t('next_story', {
+                  ? t('story.next_story', {
                       story: vm.story.next!.title
                     })
                   : null
@@ -85,7 +87,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               class="chevron"
               tuiIconButton
               tuiHintDirection="top-right"
-              [tuiHint]="t('next')"
+              [tuiHint]="t('story.next')"
               (click)="navigateToNextStory(vm.story.next!.ref)"
               type="button"></button>
             <tui-hosted-dropdown
@@ -94,7 +96,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               [(open)]="dropdownState">
               <button
                 [attr.aria-label]="
-                  t('change_view_sr', {
+                  t('story.change_view_sr', {
                     currentView: t(getCurrentViewTranslation)
                   })
                 "
@@ -104,7 +106,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
                 tuiIconButton
                 type="button"
                 tuiHintDirection="top-right"
-                [tuiHint]="t('change_view')"
+                [tuiHint]="t('story.change_view')"
                 (click)="(!dropdownState)"></button>
             </tui-hosted-dropdown>
             <tui-hosted-dropdown
@@ -112,7 +114,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               [content]="storyOptions"
               [(open)]="storyOptionsState">
               <button
-                [attr.aria-label]="t('story_options')"
+                [attr.aria-label]="t('story.story_options')"
                 icon="more-vertical"
                 data-test="story-options"
                 appearance="tertiary"
@@ -123,10 +125,10 @@ Copyright (c) 2021-present Kaleidos Ventures SL
             </tui-hosted-dropdown>
             <button
               *ngIf="vm.selectedStoryView !== 'full-view'"
-              [attr.aria-label]="t('close')"
+              [attr.aria-label]="t('story.close')"
               icon="close"
               appearance="us-header-button"
-              (click)="closeStory(vm.story?.ref)"
+              (click)="requestCloseStory()"
               tuiIconButton
               class="close-button"
               type="button"></button>
@@ -152,7 +154,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
                     t(viewOption.translation)
                   }}</span>
                 </span>
-                <span class="shortcut">{{ t('ctrl_x') }}</span>
+                <span class="shortcut">{{ t('story.ctrl_x') }}</span>
               </button>
             </tui-data-list>
           </ng-template>
@@ -172,13 +174,16 @@ Copyright (c) 2021-present Kaleidos Ventures SL
                   class="story-option-icon"
                   src="trash"></tui-svg>
                 <span class="story-option-name">{{
-                  t('delete.delete_story')
+                  t('story.delete.delete_story')
                 }}</span>
               </button>
             </tui-data-list>
           </ng-template>
         </div>
-        <tui-scrollbar class="scrollbar-content">
+        <tui-scrollbar
+          class="scrollbar-content"
+          [class.field-focus]="vm.fieldFocus"
+          [class.field-edit]="vm.fieldEdit">
           <div
             class="story-content"
             [class]="vm.selectedStoryView"
@@ -186,7 +191,11 @@ Copyright (c) 2021-present Kaleidos Ventures SL
               !sidebarOpen && vm.selectedStoryView === 'side-view'
             ">
             <div class="main-content">
-              <h1 class="title">{{ vm.story.title }}</h1>
+              <tg-story-detail-title
+                [form]="form"
+                [story]="vm.story"
+                (focusChange)="titleFocus($event)"
+                (editChange)="titleEdit($event)"></tg-story-detail-title>
               <div class="creation-info">
                 <tg-user-avatar
                   size="m"
@@ -204,7 +213,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
                     [title]="vm.story.createdAt | date: 'medium'"
                     class="creation-info-date">
                     {{
-                      t('story_date_distance', {
+                      t('story.story_date_distance', {
                         dateDistance: vm.story.createdAt | dateDistance
                       })
                     }}
@@ -247,10 +256,10 @@ Copyright (c) 2021-present Kaleidos Ventures SL
             <h3
               class="delete-story-confirm-title"
               data-test="delete-story-confirm-title">
-              {{ t('delete.confirm') }}
+              {{ t('story.delete.confirm') }}
             </h3>
             <p class="delete-story-confirm-question">
-              {{ t('delete.confirm_info') }}
+              {{ t('story.delete.confirm_info') }}
             </p>
             <div class="delete-story-confirm-actions-area">
               <button
@@ -258,7 +267,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
                 tuiButton
                 (click)="closeDeleteStoryConfirmModal()"
                 type="button">
-                {{ t('delete.cancel') }}
+                {{ t('story.delete.cancel') }}
               </button>
               <button
                 data-test="delete-story-confirm-button"
@@ -267,12 +276,17 @@ Copyright (c) 2021-present Kaleidos Ventures SL
                 icon="trash"
                 (click)="deleteStory()"
                 type="button">
-                {{ t('delete.confirm_action') }}
+                {{ t('story.delete.confirm_action') }}
               </button>
             </div>
           </ng-container>
         </tg-ui-modal>
       </div>
     </form>
+
+    <tg-discard-changes-modal
+      [open]="vm.showDiscardChangesModal"
+      (discard)="discard()"
+      (cancel)="keepEditing()"></tg-discard-changes-modal>
   </ng-container>
 </ng-container>

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.module.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.module.ts
@@ -21,6 +21,7 @@ import {
 import { InputsModule } from '@taiga/ui/inputs/inputs.module';
 import { ModalModule } from '@taiga/ui/modal';
 import { CommonTemplateModule } from '~/app/shared/common-template.module';
+import { AutoFocusDirective } from '~/app/shared/directives/auto-focus/auto-focus.directive';
 import { HasPermissionDirective } from '~/app/shared/directives/has-permissions/has-permission.directive';
 import { DropdownModule } from '~/app/shared/dropdown/dropdown.module';
 import { DateDistancePipe } from '~/app/shared/pipes/date-distance/date-distance.pipe';
@@ -32,6 +33,11 @@ import { StoryDetailAssignComponent } from './components/story-detail-assign/sto
 import { StoryDetailStatusComponent } from './components/story-detail-status/story-detail-status.component';
 import { DataAccessStoryDetailModule } from './data-access/story-detail-data-access.module';
 import { StoryDetailComponent } from './story-detail.component';
+import { StoryDetailTitleComponent } from './components/story-detail-title/story-detail-title.component';
+import { RestoreFocusDirective } from '~/app/shared/directives/restore-focus/restore-focus.directive';
+import { DiscardChangesModalComponent } from '~/app/shared/discard-changes-modal/discard-changes-modal.component';
+import { RestoreFocusTargetDirective } from '~/app/shared/directives/restore-focus/restore-focus-target.directive';
+import { FieldConflictComponent } from '../components/field-conflict/field-conflict.component';
 
 @NgModule({
   imports: [
@@ -55,11 +61,17 @@ import { StoryDetailComponent } from './story-detail.component';
     ResizeEventModule,
     HasPermissionDirective,
     ModalModule,
+    AutoFocusDirective,
+    RestoreFocusDirective,
+    RestoreFocusTargetDirective,
+    DiscardChangesModalComponent,
+    FieldConflictComponent,
   ],
   declarations: [
     StoryDetailComponent,
     StoryDetailStatusComponent,
     StoryDetailAssignComponent,
+    StoryDetailTitleComponent,
   ],
   exports: [StoryDetailComponent],
 })

--- a/javascript/apps/taiga/src/app/shared/directives/outside-click/outside-click.directive.ts
+++ b/javascript/apps/taiga/src/app/shared/directives/outside-click/outside-click.directive.ts
@@ -1,0 +1,40 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import {
+  Directive,
+  ElementRef,
+  EventEmitter,
+  HostListener,
+  Output,
+} from '@angular/core';
+
+@Directive({
+  selector: '[tgOutsideClick]',
+  standalone: true,
+})
+export class OutsideClickDirective {
+  @Output('tgOutsideClick')
+  public outsideClick = new EventEmitter<MouseEvent>();
+
+  @HostListener('document:mousedown', ['$event'])
+  public onClick(event: MouseEvent): void {
+    if (
+      event.target &&
+      !this.nativeElement.contains(event.target as HTMLElement)
+    ) {
+      this.outsideClick.emit(event);
+    }
+  }
+
+  public get nativeElement() {
+    return this.elementRef.nativeElement as HTMLElement;
+  }
+
+  constructor(private elementRef: ElementRef) {}
+}

--- a/javascript/apps/taiga/src/app/shared/directives/restore-focus/restore-focus-target.directive.ts
+++ b/javascript/apps/taiga/src/app/shared/directives/restore-focus/restore-focus-target.directive.ts
@@ -1,0 +1,33 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Directive, ElementRef, Input, OnDestroy, OnInit } from '@angular/core';
+
+import { RestoreFocusService } from './restore-focus.service';
+
+@Directive({
+  selector: '[tgRestoreFocusTarget]',
+  standalone: true,
+})
+export class RestoreFocusTargetDirective implements OnInit, OnDestroy {
+  @Input('tgRestoreFocusTarget')
+  public id!: string;
+
+  constructor(
+    private focusService: RestoreFocusService,
+    private el: ElementRef
+  ) {}
+
+  public ngOnInit(): void {
+    this.focusService.add(this.id, this.el.nativeElement as HTMLElement);
+  }
+
+  public ngOnDestroy(): void {
+    this.focusService.delete(this.id);
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/directives/restore-focus/restore-focus.directive.ts
+++ b/javascript/apps/taiga/src/app/shared/directives/restore-focus/restore-focus.directive.ts
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Directive, Input, OnDestroy } from '@angular/core';
+import { RestoreFocusService } from './restore-focus.service';
+
+@Directive({
+  selector: '[tgRestoreFocus]',
+  standalone: true,
+})
+export class RestoreFocusDirective implements OnDestroy {
+  @Input('tgRestoreFocus')
+  public id!: string;
+
+  @Input('tgRestoreFocusActive')
+  public active = true;
+
+  constructor(private focusService: RestoreFocusService) {}
+
+  public ngOnDestroy(): void {
+    if (this.active) {
+      this.focusService.focusWhenAvailable(this.id);
+    }
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/directives/restore-focus/restore-focus.service.ts
+++ b/javascript/apps/taiga/src/app/shared/directives/restore-focus/restore-focus.service.ts
@@ -1,0 +1,67 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Injectable } from '@angular/core';
+import {
+  BehaviorSubject,
+  catchError,
+  filter,
+  map,
+  of,
+  take,
+  timeout,
+} from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RestoreFocusService {
+  private previousFocus = new BehaviorSubject<Map<string, HTMLElement>>(
+    new Map()
+  );
+
+  public add(key: string, el: HTMLElement) {
+    const targetList = this.previousFocus.value;
+
+    targetList.set(key, el);
+
+    this.previousFocus.next(targetList);
+  }
+
+  public delete(key: string) {
+    const targetList = this.previousFocus.value;
+
+    targetList.delete(key);
+
+    this.previousFocus.next(targetList);
+  }
+
+  public focusWhenAvailable(key: string) {
+    this.previousFocus
+      .pipe(
+        map((targetList) => {
+          return targetList.get(key);
+        }),
+        filter((elm): elm is HTMLElement => {
+          return !!elm;
+        }),
+        take(1),
+        timeout(2000),
+        catchError(() => {
+          return of(null);
+        })
+      )
+      .subscribe((elm) => {
+        if (elm) {
+          requestAnimationFrame(() => {
+            elm.focus();
+          });
+        }
+      });
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/directives/shorcut/shorcut.directive.ts
+++ b/javascript/apps/taiga/src/app/shared/directives/shorcut/shorcut.directive.ts
@@ -1,0 +1,89 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import {
+  Directive,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { ShortcutsService } from '@taiga/core';
+import { filter } from 'rxjs';
+
+@UntilDestroy()
+@Directive({
+  selector: '[tgShortcut]',
+  standalone: true,
+})
+export class ShortcutDirective implements OnChanges, OnInit, OnDestroy {
+  @Input()
+  public tgShortcut!: typeof ShortcutsService.shortcuts[number]['task'];
+
+  @Input()
+  public tgShortcutActive = true;
+
+  @Output()
+  public tgShortcutAction = new EventEmitter<void>();
+
+  constructor(private shortcutsService: ShortcutsService) {}
+
+  public start() {
+    const task = ShortcutsService.shortcuts.find(
+      (scopes) => scopes.task === this.tgShortcut
+    );
+
+    if (task) {
+      this.shortcutsService.setScope(task.scope);
+    }
+  }
+
+  public stop() {
+    const task = ShortcutsService.shortcuts.find(
+      (scopes) => scopes.task === this.tgShortcut
+    );
+
+    if (task) {
+      this.shortcutsService.undoScope(task.scope);
+    }
+  }
+
+  public ngOnInit() {
+    this.shortcutsService
+      .task(this.tgShortcut)
+      .pipe(
+        untilDestroyed(this),
+        filter(() => this.tgShortcutActive)
+      )
+      .subscribe(() => {
+        this.tgShortcutAction.next();
+      });
+
+    if (this.tgShortcutActive) {
+      this.start();
+    }
+  }
+
+  public ngOnChanges(changes: SimpleChanges): void {
+    if (changes.tgShortcutActive) {
+      if (this.tgShortcutActive) {
+        this.start();
+      } else {
+        this.stop();
+      }
+    }
+  }
+
+  public ngOnDestroy(): void {
+    this.stop();
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/discard-changes-modal/discard-changes-modal.component.css
+++ b/javascript/apps/taiga/src/app/shared/discard-changes-modal/discard-changes-modal.component.css
@@ -1,0 +1,25 @@
+/*
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2021-present Kaleidos Ventures SL
+*/
+
+@import "tools/typography.css";
+
+.title {
+  @mixin font-heading-3;
+
+  margin-block: 0 var(--spacing-32);
+}
+
+.confirm-close-description {
+  margin-block-end: var(--spacing-32);
+}
+
+.actions {
+  display: flex;
+  gap: 2rem;
+  justify-content: flex-end;
+}

--- a/javascript/apps/taiga/src/app/shared/discard-changes-modal/discard-changes-modal.component.html
+++ b/javascript/apps/taiga/src/app/shared/discard-changes-modal/discard-changes-modal.component.html
@@ -1,0 +1,39 @@
+<!--
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Copyright (c) 2021-present Kaleidos Ventures SL
+-->
+
+<ng-container *transloco="let t">
+  <tg-ui-modal
+    class="confirm-close"
+    [open]="open"
+    [width]="500"
+    (requestClose)="cancel.next()">
+    <h1 class="title">
+      {{ t('discard_changes.title') }}
+    </h1>
+    <p class="confirm-close-description">
+      {{ t('discard_changes.description') }}
+    </p>
+    <div class="actions">
+      <button
+        type="button"
+        (click)="cancel.next()"
+        data-test="cancel-edit"
+        tuiLink>
+        {{ t('discard_changes.cancel') }}
+      </button>
+      <button
+        (click)="discard.next()"
+        data-test="confirm-edit"
+        tuiButton
+        type="button"
+        appearance="primary">
+        {{ t('discard_changes.confirm') }}
+      </button>
+    </div>
+  </tg-ui-modal>
+</ng-container>

--- a/javascript/apps/taiga/src/app/shared/discard-changes-modal/discard-changes-modal.component.ts
+++ b/javascript/apps/taiga/src/app/shared/discard-changes-modal/discard-changes-modal.component.ts
@@ -1,0 +1,45 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ModalModule } from '@taiga/ui/modal';
+import { CommonTemplateModule } from '../common-template.module';
+import { TuiLinkModule } from '@taiga-ui/core';
+import { RestoreFocusDirective } from '../directives/restore-focus/restore-focus.directive';
+
+@Component({
+  selector: 'tg-discard-changes-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ModalModule,
+    CommonTemplateModule,
+    TuiLinkModule,
+    RestoreFocusDirective,
+  ],
+  templateUrl: './discard-changes-modal.component.html',
+  styleUrls: ['./discard-changes-modal.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DiscardChangesModalComponent {
+  @Input()
+  public open = false;
+
+  @Output()
+  public discard = new EventEmitter<void>();
+
+  @Output()
+  public cancel = new EventEmitter<void>();
+}

--- a/javascript/apps/taiga/src/app/shared/story/title-validation.ts
+++ b/javascript/apps/taiga/src/app/shared/story/title-validation.ts
@@ -1,0 +1,17 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Validators } from '@angular/forms';
+
+export const StoryTitleMaxLength = 500;
+
+export const StoryTitleValidation = [
+  Validators.required,
+  Validators.maxLength(StoryTitleMaxLength),
+  Validators.pattern(/^(\s+\S+\s*)*(?!\s).*$/),
+];

--- a/javascript/apps/taiga/src/app/shared/utils/has-changes.service.ts
+++ b/javascript/apps/taiga/src/app/shared/utils/has-changes.service.ts
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Injectable } from '@angular/core';
+
+export interface HasChanges {
+  hasChanges: () => boolean;
+}
+
+@Injectable()
+export class HasChangesService {
+  private components: HasChanges[] = [];
+
+  public addComponent(component: HasChanges) {
+    this.components.push(component);
+  }
+
+  public deleteComponent(component: HasChanges) {
+    this.components = this.components.filter((it) => it !== component);
+  }
+
+  public check() {
+    return !!this.components.find((it) => it.hasChanges());
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/utils/pick.ts
+++ b/javascript/apps/taiga/src/app/shared/utils/pick.ts
@@ -1,0 +1,19 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+export function pick<T extends object, K extends keyof T>(
+  object: T,
+  keys: readonly K[]
+) {
+  return keys.reduce((acc, name) => {
+    if (name in object) {
+      acc[name] = object[name];
+    }
+    return acc;
+  }, {} as Pick<T, K>);
+}

--- a/javascript/apps/taiga/src/app/shared/utils/wait-element.ts
+++ b/javascript/apps/taiga/src/app/shared/utils/wait-element.ts
@@ -1,0 +1,47 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Observable } from 'rxjs';
+
+export function waitElement(selector: string, timeout = 1000) {
+  const findElement = () => {
+    return document.querySelector(selector);
+  };
+
+  return new Observable((subscriber) => {
+    const el = findElement();
+
+    if (el) {
+      subscriber.next(el);
+      subscriber.complete();
+    }
+
+    const timeouId = setTimeout(() => {
+      subscriber.complete();
+      observer.disconnect();
+    }, timeout);
+
+    const observer = new MutationObserver(() => {
+      const el = findElement();
+
+      if (el) {
+        clearTimeout(timeouId);
+        subscriber.next(el);
+        subscriber.complete();
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: false,
+      characterData: false,
+    });
+  });
+}

--- a/javascript/apps/taiga/src/app/styles/generic.css
+++ b/javascript/apps/taiga/src/app/styles/generic.css
@@ -223,3 +223,27 @@ textarea {
     cursor: grab !important;
   }
 }
+
+/* float: inline-(start|end) polyfill */
+
+/* stylelint-disable liberty/use-logical-spec */
+body[dir="ltr"] {
+  & .float-inline-start {
+    float: left;
+  }
+
+  & .float-inline-end {
+    float: right;
+  }
+}
+
+body[dir="rtl"] {
+  & .float-inline-start {
+    float: right;
+  }
+
+  & .float-inline-end {
+    float: left;
+  }
+}
+/* stylelint-enable liberty/use-logical-spec */

--- a/javascript/apps/taiga/src/assets/i18n/ar.json
+++ b/javascript/apps/taiga/src/assets/i18n/ar.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/bg.json
+++ b/javascript/apps/taiga/src/assets/i18n/bg.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/ca.json
+++ b/javascript/apps/taiga/src/assets/i18n/ca.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/en-US.json
@@ -36,9 +36,10 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
-    "next_page": "Next page",
     "modify": "modify",
-    "delete": "delete"
+    "delete": "delete",
+    "save": "Save",
+    "next_page": "Next page"
   },
   "navigation": {
     "go_home": "Go to home",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/es-ES.json
+++ b/javascript/apps/taiga/src/assets/i18n/es-ES.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/eu.json
+++ b/javascript/apps/taiga/src/assets/i18n/eu.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/fa.json
+++ b/javascript/apps/taiga/src/assets/i18n/fa.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/he.json
+++ b/javascript/apps/taiga/src/assets/i18n/he.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/ja.json
+++ b/javascript/apps/taiga/src/assets/i18n/ja.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/ar.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/ar.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/bg.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/bg.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/ca.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/ca.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/en-US.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/es-ES.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/es-ES.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/eu.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/eu.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/fa.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/fa.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/he.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/he.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/ja.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/ja.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/ko.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/ko.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/pt-BR.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/pt-BR.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/pt.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/pt.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/ru.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/ru.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/uk.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/uk.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/zh-Hans.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/zh-Hans.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/kanban/zh-Hant.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/zh-Hant.json
@@ -14,12 +14,5 @@
   "final_position_live_announce": "Final position {{ storyIndex }} of {{totalStories}}. Status {{status}}",
   "grabbed_live_announce": "{{title}} grabbed, current position {{position}}. Up and down arrow keys to change position, left and right arrow keys to change status, Spacebar to drop, Escape key to cancel",
   "dropped_live_announce": "{{title}} dropped",
-  "reorder_cancelled_live_announce": "reorder cancelled",
-  "create_story_form": {
-    "story_title_label": "Story title",
-    "title_story_required": "Story title can’t be empty.",
-    "create_story_button": "Create Story",
-    "max_length": "Character limit has been reached.",
-    "story_title_placeholder": "Start writing a Story title..."
-  }
+  "reorder_cancelled_live_announce": "reorder cancelled"
 }

--- a/javascript/apps/taiga/src/assets/i18n/ko.json
+++ b/javascript/apps/taiga/src/assets/i18n/ko.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/pt-BR.json
+++ b/javascript/apps/taiga/src/assets/i18n/pt-BR.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -68,7 +71,8 @@
   "main_project_navigation": {
     "goto": "Go to",
     "project_settings": "Project settings",
-    "collapse_menu": "Collapse menu"
+    "collapse_menu": "Collapse menu",
+    "expand_menu": "Expand menu"
   },
   "common_project": {
     "create_first_project": "Create your first project",
@@ -105,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -131,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/pt.json
+++ b/javascript/apps/taiga/src/assets/i18n/pt.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/ru.json
+++ b/javascript/apps/taiga/src/assets/i18n/ru.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ar.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ar.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/bg.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/bg.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ca.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ca.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/en-US.json
@@ -22,6 +22,7 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",

--- a/javascript/apps/taiga/src/assets/i18n/story/es-ES.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/es-ES.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/eu.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/eu.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/fa.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/fa.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/he.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/he.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ja.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ja.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ko.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ko.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/pt-BR.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/pt-BR.json
@@ -20,12 +20,16 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
+  "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
-    "confirm_action": "Yes, delete.",
-    "cancel": "{{commons.cancel}}"
+    "confirm_action": "Yes, delete",
+    "cancel": "{{commons.cancel}}",
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/pt.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/pt.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/ru.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/ru.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/uk.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/uk.json
@@ -22,12 +22,14 @@
   "collapse_sidebar": "Collapse sidebar",
   "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
     "confirm_action": "Yes, delete",
     "cancel": "{{commons.cancel}}",
-    "confirm_delete": "Story #{{ref}} has been deleted"
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/zh-Hans.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/zh-Hans.json
@@ -20,12 +20,16 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
+  "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
-    "confirm_action": "Yes, delete.",
-    "cancel": "{{commons.cancel}}"
+    "confirm_action": "Yes, delete",
+    "cancel": "{{commons.cancel}}",
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/story/zh-Hant.json
+++ b/javascript/apps/taiga/src/assets/i18n/story/zh-Hant.json
@@ -20,12 +20,16 @@
   "full_width_view": "Full width view",
   "ctrl_x": "Ctrl + X",
   "collapse_sidebar": "Collapse sidebar",
+  "expand_sidebar": "Expand sidebar",
   "status": "Status",
+  "edit_title": "Edit title",
   "delete": {
     "delete_story": "Delete Story",
     "confirm": "Are you sure you want to delete this story?",
     "confirm_info": "All story information will be permanently deleted. There is no undo.",
-    "confirm_action": "Yes, delete.",
-    "cancel": "{{commons.cancel}}"
+    "confirm_action": "Yes, delete",
+    "cancel": "{{commons.cancel}}",
+    "confirm_delete": "Story #{{ref}} has been deleted",
+    "confirm_delete_event": "{{username}} has deleted the story #{{ref}}"
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/uk.json
+++ b/javascript/apps/taiga/src/assets/i18n/uk.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -106,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists.",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -132,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/zh-Hans.json
+++ b/javascript/apps/taiga/src/assets/i18n/zh-Hans.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -68,7 +71,8 @@
   "main_project_navigation": {
     "goto": "Go to",
     "project_settings": "Project settings",
-    "collapse_menu": "Collapse menu"
+    "collapse_menu": "Collapse menu",
+    "expand_menu": "Expand menu"
   },
   "common_project": {
     "create_first_project": "Create your first project",
@@ -105,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -131,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/apps/taiga/src/assets/i18n/zh-Hant.json
+++ b/javascript/apps/taiga/src/assets/i18n/zh-Hant.json
@@ -36,6 +36,9 @@
     "sprints": "Sprints",
     "your_user": "{{ name }} <strong class='is-self'>(You)</strong>",
     "save_changes": "Save changes",
+    "modify": "modify",
+    "delete": "delete",
+    "save": "Save",
     "next_page": "Next page"
   },
   "navigation": {
@@ -68,7 +71,8 @@
   "main_project_navigation": {
     "goto": "Go to",
     "project_settings": "Project settings",
-    "collapse_menu": "Collapse menu"
+    "collapse_menu": "Collapse menu",
+    "expand_menu": "Expand menu"
   },
   "common_project": {
     "create_first_project": "Create your first project",
@@ -105,11 +109,9 @@
     "invalid_token_toast_message": "Invalid token.",
     "invitation_no_longer_valid": "The invitation is no longer valid.",
     "project_invitation_no_longer_valid": "The invitation to {{ name }} is no longer valid.",
-    "modify_story_permission": "You no longer have permissions to modify stories",
+    "lose_story_permissions": "You no longer have permissions to {{permission}} stories",
     "you_dont_have_permission_to_see": "You don't have permission to see the project.",
-    "admin_permission": "You  are no longer admin on this project",
-    "entity_no_longer_exists": "This {{entity}} no longer exists",
-    "user_deleted_entity": "{{user}} has deleted it, so you cannot edit it anymore."
+    "admin_permission": "You  are no longer admin on this project"
   },
   "discard_changes": {
     "title": "Discard changes?",
@@ -131,6 +133,26 @@
     "add_assignee": "Add assignee",
     "story_not_assigned_enter": "{{common_story.story_not_assigned}} Press enter to assign",
     "assigned_members": "Assigned members",
-    "unassigned-aria": "{{ name }} unassigned."
+    "unassigned-aria": "{{ name }} unassigned.",
+    "create_story_form": {
+      "story_title_label": "Story title",
+      "title_story_required": "Story title can’t be empty.",
+      "create_story_button": "Create Story",
+      "max_length": "Character limit has been reached.",
+      "story_title_placeholder": "Start writing a Story title..."
+    }
+  },
+  "field_conflict": {
+    "title": "Watch out! There is a new version of the title.",
+    "description": "While you were editing the {{fieldName}}, <strong>{{user}}</strong> saved a new version. Check it out and then you can edit it if you want.",
+    "copy": "Copy to clipboard",
+    "copied": "Copied to clipboard!",
+    "see_new_version": "See new version",
+    "dismiss": "Dismiss",
+    "copy_title": "Do you want to copy your changes?",
+    "copy_descripcion": "So you can use them later.",
+    "fields": {
+      "title": "title"
+    }
   }
 }

--- a/javascript/docs/workflows/ui/shortcuts.worflow.md
+++ b/javascript/docs/workflows/ui/shortcuts.worflow.md
@@ -44,6 +44,9 @@ this.shortcutsService.resetScope();
 
 // return to the previous scope
 this.shortcutsService.undoLastScope();
+
+// remove scope and go to the previous one
+this.shortcutsService.undoScope('scope');
 ```
 
 In this example we listen `tooltip.close` when Tooltip is instanced but we only want to listen this task when the tooltip is open so we're responsible to activate the scope and disable it when not needed.

--- a/javascript/libs/core/src/lib/services/shortcuts/shortcuts.ts
+++ b/javascript/libs/core/src/lib/services/shortcuts/shortcuts.ts
@@ -22,4 +22,14 @@ export default [
     defaultKey: 'esc',
     scope: 'assign-user',
   },
-];
+  {
+    task: 'edit-field.close',
+    defaultKey: 'esc',
+    scope: 'edit-field',
+  },
+  {
+    task: 'conflict.close',
+    defaultKey: 'esc',
+    scope: 'conflict',
+  },
+] as const;

--- a/javascript/libs/data/src/lib/story.model.mock.ts
+++ b/javascript/libs/data/src/lib/story.model.mock.ts
@@ -14,7 +14,7 @@ import {
   randText,
   randUser,
 } from '@ngneat/falso';
-import { Status, StatusMockFactory } from '..';
+import { Status, StatusMockFactory, UserMockFactory } from '..';
 import { Story, StoryDetail } from './story.model';
 
 export const StoryMockFactory = (
@@ -53,6 +53,8 @@ export const StoryDetailMockFactory = (
     titleCount = 10;
   }
 
+  const user = UserMockFactory();
+
   return {
     ref: randNumber({ min: 1, max: 999 }),
     version: randNumber(),
@@ -71,5 +73,11 @@ export const StoryDetailMockFactory = (
     },
     createdAt: randPastDate().toString(),
     assignees: [],
+    titleUpdatedAt: randPastDate().toString(),
+    titleUpdatedBy: {
+      username: user.username,
+      fullName: user.fullName,
+      color: user.color,
+    },
   };
 };

--- a/javascript/libs/data/src/lib/story.model.ts
+++ b/javascript/libs/data/src/lib/story.model.ts
@@ -31,12 +31,15 @@ export interface StoryDetail extends Story {
   };
   createdBy: createdBy;
   createdAt: string;
+  titleUpdatedAt: string;
+  titleUpdatedBy: Pick<User, 'username' | 'fullName' | 'color'>;
 }
 
 export interface StoryUpdate {
   ref: Story['ref'];
   version: Story['version'];
   status?: Story['status']['slug'];
+  title?: Story['title'];
 }
 
 export interface createdBy {

--- a/javascript/libs/ui/src/lib/inputs/form/form.directive.ts
+++ b/javascript/libs/ui/src/lib/inputs/form/form.directive.ts
@@ -28,12 +28,15 @@ export class FormDirective {
   @HostListener('submit')
   public formSubmit() {
     if (this.focusInvalidInput) {
-      const invalidControl = this.nativeElement.querySelector(
-        '.ng-invalid'
-      ) as HTMLElement;
+      const invalidControl =
+        this.nativeElement.querySelector<HTMLElement>('.ng-invalid');
 
       if (invalidControl) {
-        invalidControl.focus();
+        if (invalidControl.tagName === 'TUI-TEXT-AREA') {
+          invalidControl.querySelector('textarea')?.focus();
+        } else {
+          invalidControl.focus();
+        }
       }
     }
   }

--- a/javascript/libs/ui/src/lib/inputs/textarea/textarea.component.css
+++ b/javascript/libs/ui/src/lib/inputs/textarea/textarea.component.css
@@ -10,6 +10,8 @@ Copyright (c) 2021-present Kaleidos Ventures SL
 @import "tools/typography.css";
 
 :host {
+  --tui-error-fill-night: var(--color-red);
+
   display: block;
 
   &.invalid.show-errors {
@@ -21,19 +23,49 @@ Copyright (c) 2021-present Kaleidos Ventures SL
       & tui-wrapper::after {
         color: var(--color-red) !important;
       }
+
+      & [data-appearance="textfield"] {
+        --color-gray40: var(--color-red);
+        --tui-base-03: var(--color-red);
+      }
+
+      & tui-text-area .t-content {
+        background: var(--color-red10);
+      }
+
+      &._focused {
+        /* stylelint-disable-next-line max-nesting-depth */
+        &::after {
+          color: var(--color-red);
+        }
+      }
+    }
+  }
+}
+
+:host.invalid.show-errors:focus-within {
+  &.update-on-submit.submitted::ng-deep,
+  &.update-on-blur.dirty::ng-deep,
+  &.update-on-change.dirty::ng-deep,
+  &.update-on-blur.touched::ng-deep,
+  &.update-on-change.touched::ng-deep {
+    & tui-text-area .t-content {
+      background-color: var(--color-white);
     }
   }
 }
 
 tui-text-area {
-  --tui-error-bg-night: var(--color-red40);
-
   & ::ng-deep {
     & .placeholder {
       --tui-text-01: var(--color-gray60);
       --tui-text-02: var(--color-gray60);
     }
   }
+}
+
+.input-container {
+  margin-block-end: var(--spacing-4);
 }
 
 :host::ng-deep {

--- a/javascript/libs/ui/src/lib/modal/components/modal/modal.component.html
+++ b/javascript/libs/ui/src/lib/modal/components/modal/modal.component.html
@@ -12,6 +12,7 @@ Copyright (c) 2021-present Kaleidos Ventures SL
       <div class="modal-content-wrapper">
         <div
           class="modal-content"
+          [attr.id]="id"
           [style.--modal-width]="width + 'px'"
           [class.no-padding]="noPadding"
           [class.big]="big"


### PR DESCRIPTION
PR for #3134

## New stuff:

story-detail-title - main component of everything related to the title and edition.

field-conflict - generic component to show conflict fields.

pick - get keys from object.

HasChangesService - makes it easy to check for pending changes, to show the "discard changes" warnings.

OutsideClickDirective - Output to know when the user click outside an element. Like tuiActiveZoneChange, but it works with copy content 🤷.

FocusRestore (1 service, 2 directives) - easy focus control, example:

```html
<h1 tgRestoreFocusTarget="title"></h1>

<div *ngIf="xx" tgRestoreFocus="title">
...
</div>

<!-- Focus return to h1 when div is destroyed. -->
```



tgShortcut - control shorcuts in the html.

waitElement - wait for an element to exist, not used but useful.

polyfill for float: inline-(start|end). Needed in the top right edit button.

## Changes:

Confirm changes is now a common component `tg-discard-changes-modal`.

Move translations to common.

Move title story validations to a shared folder.

`StoryDetailEventsActions` wasn't doing anything, deleted.

Story detail padding mini refactor because title sometimes is out of boundaries.

ShortcutsService - add debug, added `undoScope` for destroying a specific scope and some bugs fixed.

New fields in StoryDetail.

Focus on textarea if it is the first field with an error.

Adding style for errors in textarea.

Shortcut collision with more than 1 modal open, fixed adding a unique scopeId and searching the modal on top, also better shortcut scope handling.
