### PR TITLE
feat(kanban): update permissions notifications

### DIFF
--- a/javascript/apps/taiga/src/app/shared/permission-update-notification/permission-update-notification.service.spec.ts
+++ b/javascript/apps/taiga/src/app/shared/permission-update-notification/permission-update-notification.service.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { ProjectMockFactory } from '@taiga/data';
+import { AppService } from '~/app/services/app.service';
+import { PermissionsService } from '~/app/services/permissions.service';
+import { PermissionUpdateNotificationService } from './permission-update-notification.service';
+
+describe('PermissionUpdateNotificationServiceService', () => {
+  let spectator: SpectatorService<PermissionUpdateNotificationService>;
+  const createService = createServiceFactory({
+    service: PermissionUpdateNotificationService,
+    mocks: [PermissionsService, AppService],
+  });
+
+  beforeEach(() => (spectator = createService()));
+
+  describe('apply permission to formGroup', () => {
+    it('no access - disable form', () => {
+      expect(true).toBeTruthy();
+    });
+
+    it('notify Lose Permissions - has some permissions', () => {
+      const previousProject = ProjectMockFactory();
+      previousProject.userPermissions = [
+        'story_create',
+        'story_modify',
+        'story_delete',
+      ];
+      const currentProject = ProjectMockFactory();
+      currentProject.userPermissions = ['story_create', 'story_modify'];
+      const permissionsService = spectator.inject(PermissionsService);
+      spectator.service.notify = jest.fn();
+
+      permissionsService.hasPermissions.mockReturnValue(true);
+
+      spectator.service.notifyLosePermissions(previousProject, currentProject);
+      expect(spectator.service.notify).toHaveBeenCalledWith(
+        'edit_story_lost_some_permission'
+      );
+    });
+
+    it('notify Lose Permissions - has NO permissions', () => {
+      const previousProject = ProjectMockFactory();
+      previousProject.userPermissions = [
+        'story_create',
+        'story_modify',
+        'story_delete',
+      ];
+      const currentProject = ProjectMockFactory();
+      currentProject.userPermissions = ['story_create', 'story_modify'];
+      const permissionsService = spectator.inject(PermissionsService);
+      spectator.service.notify = jest.fn();
+
+      permissionsService.hasPermissions.mockReturnValue(false);
+
+      spectator.service.notifyLosePermissions(previousProject, currentProject);
+      expect(spectator.service.notify).toHaveBeenCalledWith(
+        'edit_story_lost_permission'
+      );
+    });
+  });
+});

--- a/javascript/apps/taiga/src/app/shared/permission-update-notification/permission-update-notification.service.ts
+++ b/javascript/apps/taiga/src/app/shared/permission-update-notification/permission-update-notification.service.ts
@@ -1,0 +1,53 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2021-present Kaleidos Ventures SL
+ */
+
+import { Injectable } from '@angular/core';
+import { TuiNotification } from '@taiga-ui/core';
+import { Project } from '@taiga/data';
+import { AppService } from '~/app/services/app.service';
+import { PermissionsService } from '~/app/services/permissions.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PermissionUpdateNotificationService {
+  constructor(
+    private permissionService: PermissionsService,
+    private appService: AppService
+  ) {}
+
+  public notifyLosePermissions(
+    previousProject: Project,
+    currentProject: Project
+  ) {
+    if (
+      previousProject?.userPermissions.length >
+      currentProject?.userPermissions.length
+    ) {
+      const hasStoryPermissions = this.permissionService.hasPermissions(
+        'story',
+        ['create', 'delete', 'modify'],
+        'OR'
+      );
+      if (hasStoryPermissions) {
+        this.notify('edit_story_lost_some_permission');
+      } else {
+        this.notify('edit_story_lost_permission');
+      }
+    }
+  }
+
+  public notify(translation: string) {
+    this.appService.toastNotification({
+      message: translation,
+      status: TuiNotification.Warning,
+      scope: 'kanban',
+      autoClose: true,
+    });
+  }
+}

--- a/javascript/apps/taiga/src/assets/i18n/kanban/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/kanban/en-US.json
@@ -5,6 +5,8 @@
   "empty_status": "There are no stories.",
   "add_story": "Add story",
   "create_story_permission": "You no longer have permissions to create stories",
+  "edit_story_lost_permission": "You no longer have permission to edit stories",
+  "edit_story_lost_some_permission": "You have lost some permissions to edit stories",
   "lost_kanban_access": "You no longer have permissions to access this content.",
   "story_title": "{{ref}} {{title}}. Position {{position}} of {{total}}",
   "story_title_a11y": "Position {{position}} of {{total}}. Press Spacebar to Reorder.",


### PR DESCRIPTION
**HOW TO TEST**

If a user is in the kanban or the story detail and loses permissions to create, modify or delete stories should be notified.

- The toast will have different messages whether the user has lost **some permissions** or **all permissions*.