### PR TITLE
feat(workspace): delete endpoint

### DIFF
--- a/python/apps/taiga/src/taiga/workspaces/workspaces/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/events/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.events import events_manager
+from taiga.users.models import AnyUser
+from taiga.workspaces.workspaces.events.content import DeleteWorkspaceContent
+from taiga.workspaces.workspaces.models import Workspace
+
+WORKSPACE_DELETE = "workspaces.delete"
+
+
+async def emit_event_when_workspace_is_deleted(workspace: Workspace, deleted_by: AnyUser) -> None:
+    # for ws-members, both in the home page and in the ws-detail
+    await events_manager.publish_on_workspace_channel(
+        workspace=workspace,
+        type=WORKSPACE_DELETE,
+        content=DeleteWorkspaceContent(workspace=workspace.id, name=workspace.name, deleted_by=deleted_by),
+    )

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/events/content.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/events/content.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.base.serializers import UUIDB64, BaseModel
+from taiga.users.serializers.nested import UserNestedSerializer
+
+
+class DeleteWorkspaceContent(BaseModel):
+    workspace: UUIDB64
+    name: str
+    deleted_by: UserNestedSerializer

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/repositories.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/repositories.py
@@ -373,3 +373,17 @@ def update_workspace(workspace: Workspace, values: dict[str, Any] = {}) -> Works
 
     workspace.save()
     return workspace
+
+
+
+##########################################################
+# delete workspace
+##########################################################
+
+
+@sync_to_async
+def delete_workspaces(filters: WorkspaceFilters = {}) -> int:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    count, _ = qs.delete()
+    return count
+

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/services/exceptions.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/services/exceptions.py
@@ -3,11 +3,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
-# Copyright (c) 2023-present Kaleidos INC
+# Copyright (c) 2021-present Kaleidos Ventures SL
 
 
 from taiga.base.services.exceptions import TaigaServiceException
 
 
 class TaigaValidationError(TaigaServiceException):
+    ...
+
+
+class WorkspaceHasProjects(TaigaServiceException):
     ...

--- a/python/apps/taiga/tests/integration/taiga/workspaces/workspaces/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/workspaces/test_repositories.py
@@ -487,6 +487,29 @@ async def test_get_user_workspaces_overview_invited_projects():
 
 
 ##########################################################
+# delete_workspace
+##########################################################
+
+
+async def test_delete_workspaces_without_ws_members():
+    workspace = await f.create_workspace()
+
+    num_deleted_wss = await repositories.delete_workspaces(filters={"id": workspace.id})
+    assert num_deleted_wss == 4  # 1 workspace, 2 ws_roles (admin/member), 1 ws_memberships (admin-ws.owner)
+
+
+async def test_delete_workspaces_with_ws_members():
+    workspace = await f.create_workspace()
+
+    ws_member = await f.create_user()
+    ws_member_role = await _get_ws_member_role(workspace=workspace)
+    await f.create_workspace_membership(user=ws_member, workspace=workspace, role=ws_member_role)
+
+    num_deleted_wss = await repositories.delete_workspaces(filters={"id": workspace.id})
+    assert num_deleted_wss == 5  # 1 workspace, 2 ws_roles, 2 ws_memberships (ws.owner, ws_member)
+
+
+##########################################################
 # misc - get_user_workspace_overview
 ##########################################################
 

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -384,7 +384,22 @@ We may also have events that affect only a subset of atributes of an object; for
 We can send actions inside an event. The type must be `action` and the content should be an action described above.
 
 
-#### `projects.delete`
+#### **workspaces.delete**
+
+It happens when a workspace is deleted
+
+Content for:
+- workspace channel:
+  ```
+  {
+      "workspace": "workspace_id",
+      "name": "workspace name (str)",
+      "deleted_by": {... basic user info ...}
+  }
+  ```
+  
+
+#### **projects.delete**
 
 It happens when a project is deleted
 
@@ -612,3 +627,4 @@ Content for:
       "story": {... "story object" ...}
   }
   ```
+  

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "b63370a0-e9e7-4ab7-9c14-31fd741ae783",
+		"_postman_id": "dfcb7120-722e-4634-a41d-085008d2f958",
 		"name": "taiga-next",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9835734"
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -692,6 +692,56 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"name\": \"New name\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/workspaces/{{ws-id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"workspaces",
+								"{{ws-id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete workspace",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "6768a0ad-7c08-4aa9-a10f-d29811ff2815",
+		"_postman_id": "db2e4d45-e67f-4ed0-9db5-df2444308acf",
 		"name": "taiga-next e2e",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9835734"
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -842,6 +842,134 @@
 							"path": [
 								"auth",
 								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "N/A 200 workspaces",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"    pm.environment.set(\"ws-id\", pm.response.json().id);",
+									"});",
+									"",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    // Validate response API fields",
+									"    pm.expect(jsonRes).to.have.property(\"id\");",
+									"    pm.expect(jsonRes).to.have.property(\"isPremium\");",
+									"",
+									"    pm.expect(jsonRes.name).to.be.eql(\"My workspace\");",
+									"    pm.expect(jsonRes.color).to.be.eql(1);",
+									"",
+									"    // Validate we're not returning more fields than expected",
+									"    var numOfReturnedFields = Object.keys(jsonRes).length;",
+									"    pm.expect(numOfReturnedFields).to.equal(9);",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"name\": \"My workspace\",\n  \"color\": 1\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/workspaces",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"workspaces"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "204 workspaces.{p}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(204);",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/workspaces/{{ws-id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"workspaces",
+								"{{ws-id}}"
 							]
 						}
 					},


### PR DESCRIPTION
This PR adds the endpoint to delete a workspace (just if there's no project linked to it).

You can review the [US in Taiga](https://tree.taiga.io/project/taiga-next/us/1597) for more details, as well as its API and related events.

![gif](https://media.giphy.com/media/ylyUQlf4VUVF9odXKU/giphy.gif)

### What to test

- [x] Tests are green
- [x] Review the code

Create an empty workspace, add a (non-admin) ws-member, and create a project for this workspace
- [x] Being logged as the ws-member and trying to delete the ws, the API returns a 403-forbidden error
- [x] Being logged as the ws-admin and trying to delete the ws with a wrong id, the API returns a 404 error
- [x] Being logged as the ws-admin and trying to delete the ws, the API returns a 400 error (it has projects and can't be deleted)

Delete the previous project (now the workspace can be deleted) and re-attempt to delete the ws as the ws-admin:
- [x] The API now returns a 204
- [x] The workspace, the workspace's roles, the workspace's memberships are deleted in the database


