### PR TITLE
fix: i#3430 split fragment from previous url because it doesn't work …

### DIFF
--- a/javascript/apps/taiga/src/app/shared/route-history/route-history.service.ts
+++ b/javascript/apps/taiga/src/app/shared/route-history/route-history.service.ts
@@ -17,6 +17,7 @@ import { filter, pairwise } from 'rxjs/operators';
 })
 export class RouteHistoryService {
   public previousUrl!: string;
+  public previousFragment!: string;
   public urlChanged = new Subject<{ url: string; state: unknown }>();
 
   constructor(private router: Router, private location: Location) {
@@ -34,14 +35,24 @@ export class RouteHistoryService {
         pairwise()
       )
       .subscribe((events) => {
-        if (this.previousUrl !== events[0].urlAfterRedirects) {
-          this.previousUrl = events[0].urlAfterRedirects;
+        const urlAfterRedirects = events[0].urlAfterRedirects.split('#');
+
+        if (
+          this.previousUrl !== urlAfterRedirects[0] ||
+          this.previousFragment !== urlAfterRedirects[1]
+        ) {
+          this.previousUrl = urlAfterRedirects[0];
+          this.previousFragment = urlAfterRedirects[1];
         }
       });
   }
 
   public getPreviousUrl(): string {
     return this.previousUrl;
+  }
+
+  public getPreviousFragment(): string {
+    return this.previousFragment;
   }
 
   public back() {


### PR DESCRIPTION
…with routerlink as string