### PR TITLE
feat(workspace): list workspace memberships

### DIFF
--- a/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
@@ -24,7 +24,7 @@ from taiga.projects.projects.api import get_project_or_404
 from taiga.routers import routes
 
 # PERMISSIONS
-GET_PROJECT_MEMBERSHIPS = CanViewProject()
+LIST_PROJECT_MEMBERSHIPS = CanViewProject()
 UPDATE_PROJECT_MEMBERSHIP = IsProjectAdmin()
 
 
@@ -36,22 +36,22 @@ UPDATE_PROJECT_MEMBERSHIP = IsProjectAdmin()
 @routes.projects.get(
     "/{id}/memberships",
     name="project.memberships.list",
-    summary="Get project memberships",
+    summary="List project memberships",
     response_model=list[ProjectMembershipSerializer],
     responses=ERROR_404 | ERROR_422,
 )
-async def get_project_memberships(
+async def list_project_memberships(
     request: AuthRequest,
     response: Response,
     pagination_params: PaginationQuery = Depends(),
     id: B64UUID = Query(None, description="the project id (B64UUID)"),
 ) -> list[ProjectMembership]:
     """
-    Get project memberships
+    List project memberships
     """
 
     project = await get_project_or_404(id)
-    await check_permissions(permissions=GET_PROJECT_MEMBERSHIPS, user=request.user, obj=project)
+    await check_permissions(permissions=LIST_PROJECT_MEMBERSHIPS, user=request.user, obj=project)
 
     pagination, memberships = await memberships_services.list_paginated_project_memberships(
         project=project, offset=pagination_params.offset, limit=pagination_params.limit

--- a/python/apps/taiga/src/taiga/routers/loader.py
+++ b/python/apps/taiga/src/taiga/routers/loader.py
@@ -25,6 +25,7 @@ from taiga.system import api as system_api  # noqa
 from taiga.users import api as users_api  # noqa
 from taiga.workflows import api as workflows_api  # noqa
 from taiga.workspaces.workspaces import api as workspaces_api  # noqa
+from taiga.workspaces.memberships import api as workspaces_memberships_api  # noqa
 
 
 def load_routes(api: FastAPI) -> None:

--- a/python/apps/taiga/src/taiga/workspaces/memberships/api.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/api.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from fastapi import Depends, Query, Response
+from taiga.base.api import AuthRequest
+from taiga.base.api import pagination as api_pagination
+from taiga.base.api import responses
+from taiga.base.api.pagination import PaginationQuery
+from taiga.base.api.permissions import check_permissions
+from taiga.base.validators import B64UUID
+from taiga.exceptions.api.errors import ERROR_404, ERROR_422
+from taiga.permissions import IsWorkspaceAdmin
+from taiga.routers import routes
+from taiga.workspaces.memberships import services as memberships_services
+from taiga.workspaces.memberships.serializers import WorkspaceMembershipDetailSerializer
+from taiga.workspaces.workspaces.api import get_workspace_or_404
+
+# PERMISSIONS
+LIST_WORKSPACE_MEMBERSHIPS = IsWorkspaceAdmin()
+
+# HTTP 200 RESPONSES
+LIST_WS_MEMBERSHIP_DETAIL_200 = responses.http_status_200(model=list[WorkspaceMembershipDetailSerializer])
+
+
+##########################################################
+# list workspace memberships
+##########################################################
+
+
+@routes.workspaces.get(
+    "/{id}/memberships",
+    name="workspace.memberships.list",
+    summary="List workspace memberships",
+    responses=LIST_WS_MEMBERSHIP_DETAIL_200 | ERROR_404 | ERROR_422,
+)
+async def list_workspace_memberships(
+    request: AuthRequest,
+    response: Response,
+    pagination_params: PaginationQuery = Depends(),
+    id: B64UUID = Query(None, description="the workspace id (B64UUID)"),
+) -> list[WorkspaceMembershipDetailSerializer]:
+    """
+    List workspace memberships
+    """
+    workspace = await get_workspace_or_404(id)
+    await check_permissions(permissions=LIST_WORKSPACE_MEMBERSHIPS, user=request.user, obj=workspace)
+
+    pagination, memberships = await memberships_services.list_paginated_workspace_memberships(
+        workspace=workspace, offset=pagination_params.offset, limit=pagination_params.limit
+    )
+    api_pagination.set_pagination(response=response, pagination=pagination)
+
+    return memberships

--- a/python/apps/taiga/src/taiga/workspaces/memberships/repositories.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/repositories.py
@@ -49,6 +49,28 @@ def _apply_select_related_to_queryset(
     return qs.select_related(*select_related)
 
 
+WorkspaceMembershipOrderBy = list[
+    Literal[
+        "full_name",
+    ]
+]
+
+
+def _apply_order_by_to_queryset(
+    qs: QuerySet[WorkspaceMembership],
+    order_by: WorkspaceMembershipOrderBy,
+) -> QuerySet[WorkspaceMembership]:
+    order_by_data = []
+
+    for key in order_by:
+        if key == "full_name":
+            order_by_data.append("user__full_name")
+        else:
+            order_by_data.append(key)
+
+    return qs.order_by(*order_by_data)
+
+
 ##########################################################
 # create workspace membership
 ##########################################################
@@ -57,6 +79,29 @@ def _apply_select_related_to_queryset(
 @sync_to_async
 def create_workspace_membership(user: User, workspace: Workspace) -> WorkspaceMembership:
     return WorkspaceMembership.objects.create(user=user, workspace=workspace)
+
+
+##########################################################
+# list project memberships
+##########################################################
+
+
+@sync_to_async
+def list_workspace_memberships(
+    filters: WorkspaceMembershipFilters = {},
+    select_related: WorkspaceMembershipSelectRelated = [],
+    order_by: WorkspaceMembershipOrderBy = ["full_name"],
+    offset: int | None = None,
+    limit: int | None = None,
+) -> list[WorkspaceMembership]:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    qs = _apply_select_related_to_queryset(qs=qs, select_related=select_related)
+    qs = _apply_order_by_to_queryset(order_by=order_by, qs=qs)
+
+    if limit is not None and offset is not None:
+        limit += offset
+
+    return list(qs[offset:limit])
 
 
 ##########################################################
@@ -75,3 +120,14 @@ def get_workspace_membership(
         return qs.get()
     except WorkspaceMembership.DoesNotExist:
         return None
+
+
+##########################################################
+# misc
+##########################################################
+
+
+@sync_to_async
+def get_total_workspace_memberships(filters: WorkspaceMembershipFilters = {}) -> int:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    return qs.count()

--- a/python/apps/taiga/src/taiga/workspaces/memberships/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/serializers/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from taiga.base.serializers import BaseModel
+from taiga.projects.projects.serializers.nested import ProjectNestedSerializer
+from taiga.users.serializers.nested import UserNestedSerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceSmallNestedSerializer
+
+
+class WorkspaceMembershipDetailSerializer(BaseModel):
+    user: UserNestedSerializer
+    workspace: WorkspaceSmallNestedSerializer
+    projects: list[ProjectNestedSerializer]
+
+    class Config:
+        orm_mode = True

--- a/python/apps/taiga/src/taiga/workspaces/memberships/serializers/services.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/serializers/services.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+from taiga.projects.projects.models import Project
+from taiga.users.models import User
+from taiga.workspaces.memberships.serializers import WorkspaceMembershipDetailSerializer
+from taiga.workspaces.workspaces.models import Workspace
+
+
+def serialize_workspace_membership_detail(
+    user: User, workspace: Workspace, projects: list[Project]
+) -> WorkspaceMembershipDetailSerializer:
+    return WorkspaceMembershipDetailSerializer(
+        user=user,
+        workspace=workspace,
+        projects=projects,
+    )

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/serializers/nested.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/serializers/nested.py
@@ -8,8 +8,20 @@
 from taiga.base.serializers import UUIDB64, BaseModel
 
 
+class WorkspaceSmallNestedSerializer(BaseModel):
+    id: UUIDB64
+    name: str
+    slug: str
+
+    class Config:
+        orm_mode = True
+
+
 class WorkspaceNestedSerializer(BaseModel):
     id: UUIDB64
     name: str
     slug: str
     user_role: str
+
+    class Config:
+        orm_mode = True

--- a/python/apps/taiga/tests/integration/taiga/projects/memberships/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/projects/memberships/test_api.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.django_db
 
 
 ##########################################################
-# GET /projects/<id>/memberships
+# LIST /projects/<id>/memberships
 ##########################################################
 
 
@@ -62,7 +62,7 @@ async def test_get_project_memberships_with_pagination(client):
     assert response.headers["Pagination-Total"] == "3"
 
 
-async def test_get_project_memberships_wrong_id(client):
+async def test_list_project_memberships_wrong_id(client):
     project = await f.create_project()
     non_existent_id = "xxxxxxxxxxxxxxxxxxxxxx"
 
@@ -71,7 +71,7 @@ async def test_get_project_memberships_wrong_id(client):
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
 
 
-async def test_get_project_memberships_not_a_member(client):
+async def test_list_project_memberships_not_a_member(client):
     project = await f.create_project()
     not_a_member = await f.create_user()
 

--- a/python/apps/taiga/tests/integration/taiga/workspaces/memberships/__init__.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/memberships/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC

--- a/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_api.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+import pytest
+from fastapi import status
+from tests.utils import factories as f
+
+pytestmark = pytest.mark.django_db
+
+
+##########################################################
+# LIST /workspaces/<id>/memberships
+##########################################################
+
+
+async def test_list_workspace_memberships(client):
+    workspace = await f.create_workspace()
+    ws_member = await f.create_user()
+    await f.create_workspace_membership(user=ws_member, workspace=workspace)
+
+    client.login(ws_member)
+    response = client.get(f"/workspaces/{workspace.b64id}/memberships")
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+
+async def test_list_workspace_memberships_with_pagination(client):
+    workspace = await f.create_workspace()
+    ws_member1 = await f.create_user()
+    ws_member2 = await f.create_user()
+    await f.create_workspace_membership(user=ws_member1, workspace=workspace)
+    await f.create_workspace_membership(user=ws_member2, workspace=workspace)
+
+    client.login(workspace.created_by)
+
+    offset = 0
+    limit = 1
+
+    response = client.get(f"/workspaces/{workspace.b64id}/memberships?offset={offset}&limit={limit}")
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert len(response.json()) == 1
+    assert response.headers["Pagination-Offset"] == "0"
+    assert response.headers["Pagination-Limit"] == "1"
+    assert response.headers["Pagination-Total"] == "3"
+
+
+async def test_list_workspace_memberships_wrong_id(client):
+    workspace = await f.create_workspace()
+    non_existent_id = "xxxxxxxxxxxxxxxxxxxxxx"
+
+    client.login(workspace.created_by)
+
+    response = client.get(f"/workspaces/{non_existent_id}/memberships")
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+
+async def test_list_workspace_memberships_not_a_member(client):
+    workspace = await f.create_workspace()
+    not_a_member = await f.create_user()
+
+    client.login(not_a_member)
+
+    response = client.get(f"/workspaces/{workspace.b64id}/memberships")
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text

--- a/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_repositories.py
@@ -30,6 +30,25 @@ async def test_create_workspace_membership():
 
 
 ##########################################################
+# list_workspaces_memberships
+##########################################################
+
+
+async def test_list_project_memberships():
+    admin = await f.create_user()
+    user1 = await f.create_user()
+    user2 = await f.create_user()
+    workspace = await f.create_workspace(created_by=admin)
+    await repositories.create_workspace_membership(user=user1, workspace=workspace)
+    await repositories.create_workspace_membership(user=user2, workspace=workspace)
+
+    memberships = await repositories.list_workspace_memberships(
+        filters={"workspace_id": workspace.id}, offset=0, limit=100
+    )
+    assert len(memberships) == 3
+
+
+##########################################################
 # get_workspace_membership
 ##########################################################
 
@@ -50,3 +69,20 @@ async def test_get_workspace_membership_none():
         filters={"user_id": uuid.uuid1(), "workspace_id": uuid.uuid1()}
     )
     assert membership is None
+
+
+##########################################################
+# misc - get_total_project_memberships
+##########################################################
+
+
+async def test_get_total_workspaces_memberships():
+    admin = await f.create_user()
+    user1 = await f.create_user()
+    user2 = await f.create_user()
+    workspace = await f.create_workspace(created_by=admin)
+    await repositories.create_workspace_membership(user=user1, workspace=workspace)
+    await repositories.create_workspace_membership(user=user2, workspace=workspace)
+
+    total_memberships = await repositories.get_total_workspace_memberships(filters={"workspace_id": workspace.id})
+    assert total_memberships == 3

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "e0fb6bb4-aaca-4c48-acb1-384b43de5730",
+		"_postman_id": "04e8caa8-9825-4e42-ab07-2e96c128091e",
 		"name": "taiga-next",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9835734"
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -757,6 +757,65 @@
 							"path": [
 								"workspaces",
 								"{{ws-id}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "workspace memberships",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": []
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/workspaces/{{ws-id}}/memberships?offset={{offset}}&limit={{limit}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"workspaces",
+								"{{ws-id}}",
+								"memberships"
+							],
+							"query": [
+								{
+									"key": "offset",
+									"value": "{{offset}}"
+								},
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								}
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "3a719338-0ddd-414d-8be6-9110c27620f1",
+		"_postman_id": "5a763800-95a1-4953-9114-3299adf9fb7a",
 		"name": "taiga-next e2e",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -6174,6 +6175,282 @@
 								"{{pj-id}}",
 								"memberships",
 								"{{username}}"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "workspace.{w}.memberships",
+			"item": [
+				{
+					"name": "200 workspaces.{w}.memberships",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    var membership = jsonRes[0];",
+									"",
+									"    pm.response.to.have.header(\"Pagination-Offset\");",
+									"    pm.response.to.have.header(\"Pagination-Limit\");",
+									"    pm.response.to.have.header(\"Pagination-Total\");",
+									"",
+									"    pm.expect(membership).to.have.property(\"user\");",
+									"    pm.expect(membership).to.have.property(\"workspace\");",
+									"    pm.expect(membership).to.have.property(\"projects\");",
+									"",
+									"    var membershipUser = jsonRes[0].user;",
+									"\tvar membershipWorkspace = jsonRes[0].workspace;",
+									"   \tvar membershipProjects = jsonRes[0].projects[0];",
+									"    ",
+									"    pm.expect(membershipWorkspace).to.have.property(\"id\");",
+									"    pm.expect(membershipWorkspace).to.have.property(\"name\");",
+									"    pm.expect(membershipWorkspace).to.have.property(\"slug\");",
+									"",
+									"    pm.expect(membershipUser).to.have.property(\"username\");",
+									"    pm.expect(membershipUser).to.have.property(\"fullName\");",
+									"    pm.expect(membershipUser).to.have.property(\"color\");",
+									"",
+									"    // Validate we're not returning more fields than expected",
+									"    var numOfReturnedFields = Object.keys(membership).length;",
+									"    var numOfReturnedUserFields = Object.keys(membershipUser).length;",
+									"\tvar numOfReturnedWorkspaceFields = Object.keys(membershipWorkspace).length;",
+									"    ",
+									"\tpm.expect(numOfReturnedFields).not.to.equal(0);",
+									"\tpm.expect(numOfReturnedUserFields).to.equal(3);",
+									"\tpm.expect(numOfReturnedWorkspaceFields).to.equal(3);",
+									"",
+									"    pm.expect( Object.keys(membershipProjects).length).to.equal(8);",
+									"    pm.expect(membershipProjects).to.have.property(\"logo\");",
+									"    pm.expect(membershipProjects).to.have.property(\"logoSmall\");",
+									"    pm.expect(membershipProjects).to.have.property(\"logoLarge\");",
+									"    pm.expect(membershipProjects).to.have.property(\"id\");",
+									"    pm.expect(membershipProjects).to.have.property(\"name\");",
+									"    pm.expect(membershipProjects).to.have.property(\"slug\");",
+									"    pm.expect(membershipProjects).to.have.property(\"description\");",
+									"    pm.expect(membershipProjects).to.have.property(\"color\");",
+									"",
+									"    ",
+									"});",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": []
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/workspaces/{{ws-id}}/memberships?offset={{offset}}&limit={{limit}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"workspaces",
+								"{{ws-id}}",
+								"memberships"
+							],
+							"query": [
+								{
+									"key": "offset",
+									"value": "{{offset}}"
+								},
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "projects.{p}.workspace_member_permissions",
+			"item": [
+				{
+					"name": "N/A log in as 1000user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"    pm.environment.set(\"auth_token\", pm.response.json().token);",
+									"    pm.environment.set(\"refresh_token\", pm.response.json().refresh);",
+									"});",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"warning": "This is a duplicate header and will be overridden by the Content-Type header generated by Postman.",
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"1000user\",\n    \"password\": \"123123\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/auth/token",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"auth",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "N/A log in as 1000user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"    pm.environment.set(\"auth_token\", pm.response.json().token);",
+									"    pm.environment.set(\"refresh_token\", pm.response.json().refresh);",
+									"});",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"warning": "This is a duplicate header and will be overridden by the Content-Type header generated by Postman.",
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"username\": \"1000user\",\n    \"password\": \"123123\"\n}"
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/auth/token",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"auth",
+								"token"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "N/A my.workspaces",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Save projects slugs in environment\", function () {",
+									"    res = pm.response.json();",
+									"    // store a project containing latestProjects",
+									"    for (var ws of res) {",
+									"        if (ws.latestProjects.length > 0) {",
+									"            pm.environment.set(\"pj-id\", ws.latestProjects[0].id);",
+									"            break;",
+									"        }   ",
+									"    }    ",
+									"});",
+									"",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/workspaces",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"my",
+								"workspaces"
 							]
 						}
 					},


### PR DESCRIPTION
This PR adds the endpoint to recover the memberships of a workspace, partially covering these two USs:
- [WS page navigation & layout](https://tree.taiga.io/project/taiga-next/us/3172?milestone=341345)
- [Projects each person is a member](https://tree.taiga.io/project/taiga-next/us/3223?milestone=341345)

**GET /workspaces/{id}/memberships**

![gif](https://media.giphy.com/media/7frSUXgbGqQPKNnJRS/giphy.gif)

> **NOTE**: the list of non-ws-members will be covered in another PR


### What to test

- [x] Review the code
- [x] Tests are green

Check the database for a workspace with several members and at least a project including several members from the same workspace. Log in as the ws-admin (or any of its ws-members), and request the list of its members:
- [x] The API fulfilled the API_URL response format
- [x] The values in the response are correct (user, workspace, role, projects)
- [x] A wrong workspace id gives a 404 status
- [x] Not being a ws-admin/ws-member gives a 403 Forbidden