### PR TITLE
U/3565/remove membership endpoint

### DIFF
--- a/python/apps/taiga/src/taiga/routers/loader.py
+++ b/python/apps/taiga/src/taiga/routers/loader.py
@@ -24,8 +24,8 @@ from taiga.stories.stories import api as stories_api  # noqa
 from taiga.system import api as system_api  # noqa
 from taiga.users import api as users_api  # noqa
 from taiga.workflows import api as workflows_api  # noqa
-from taiga.workspaces.workspaces import api as workspaces_api  # noqa
 from taiga.workspaces.memberships import api as workspaces_memberships_api  # noqa
+from taiga.workspaces.workspaces import api as workspaces_api  # noqa
 
 
 def load_routes(api: FastAPI) -> None:
@@ -38,5 +38,6 @@ def load_routes(api: FastAPI) -> None:
     api.include_router(routes.projects)
     api.include_router(routes.unauth_projects)
     api.include_router(routes.workspaces)
+    api.include_router(routes.workspaces_memberships)
     api.include_router(routes.my)
     api.include_router(routes.system)

--- a/python/apps/taiga/src/taiga/routers/routes.py
+++ b/python/apps/taiga/src/taiga/routers/routes.py
@@ -51,6 +51,15 @@ tags_metadata.append(
     }
 )
 
+# /workspaces/{id}/memberships
+workspaces_memberships = AuthAPIRouter(tags=["workspaces memberships"])
+tags_metadata.append(
+    {
+        "name": "workspaces memberships",
+        "description": "Endpoint for workspaces memberships resources.",
+    }
+)
+
 # /my
 my = AuthAPIRouter(prefix="/my", tags=["my"])
 tags_metadata.append({"name": "my", "description": "Endpoints for logged-in user's resources."})

--- a/python/apps/taiga/src/taiga/users/admin.py
+++ b/python/apps/taiga/src/taiga/users/admin.py
@@ -43,7 +43,7 @@ class ProjectMembershipsInline(admin.TabularInline[ProjectMembership, User]):
 
 class WorkspaceMembershipsInline(admin.TabularInline[WorkspaceMembership, User]):
     model = WorkspaceMembership
-    fields = ("workspace", "role")
+    fields = ("workspace",)
     extra = 0
 
     def has_change_permission(self, request: HttpRequest, obj: Any = None) -> bool:

--- a/python/apps/taiga/src/taiga/workspaces/memberships/api.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/api.py
@@ -4,24 +4,28 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright (c) 2023-present Kaleidos INC
+from uuid import UUID
 
-from fastapi import Depends, Query, Response
+from fastapi import Depends, Query, Response, status
 from taiga.base.api import AuthRequest
 from taiga.base.api import pagination as api_pagination
 from taiga.base.api import responses
 from taiga.base.api.pagination import PaginationQuery
 from taiga.base.api.permissions import check_permissions
 from taiga.base.validators import B64UUID
-from taiga.exceptions.api.errors import ERROR_404, ERROR_422
+from taiga.exceptions import api as ex
+from taiga.exceptions.api.errors import ERROR_403, ERROR_404, ERROR_422
 from taiga.permissions import IsWorkspaceAdmin
 from taiga.routers import routes
 from taiga.workspaces.memberships import services as memberships_services
+from taiga.workspaces.memberships.models import WorkspaceMembership
 from taiga.workspaces.memberships.serializers import WorkspaceGuestDetailSerializer, WorkspaceMembershipDetailSerializer
 from taiga.workspaces.workspaces.api import get_workspace_or_404
 
 # PERMISSIONS
 LIST_WORKSPACE_MEMBERSHIPS = IsWorkspaceAdmin()
 LIST_WORKSPACE_GUESTS = IsWorkspaceAdmin()
+DELETE_WORKSPACE_MEMBERSHIP = IsWorkspaceAdmin()
 
 # HTTP 200 RESPONSES
 LIST_WS_MEMBERSHIP_DETAIL_200 = responses.http_status_200(model=list[WorkspaceMembershipDetailSerializer])
@@ -33,8 +37,8 @@ LIST_WS_GUESTS_DETAIL_200 = responses.http_status_200(model=list[WorkspaceGuestD
 ##########################################################
 
 
-@routes.workspaces.get(
-    "/{id}/memberships",
+@routes.workspaces_memberships.get(
+    "/workspaces/{id}/memberships",
     name="workspace.memberships.list",
     summary="List workspace memberships",
     responses=LIST_WS_MEMBERSHIP_DETAIL_200 | ERROR_404 | ERROR_422,
@@ -64,8 +68,8 @@ async def list_workspace_memberships(
 ##########################################################
 
 
-@routes.workspaces.get(
-    "/{id}/guests",
+@routes.workspaces_memberships.get(
+    "/workspaces/{id}/guests",
     name="workspace.guests.list",
     summary="List workspace guests",
     responses=LIST_WS_GUESTS_DETAIL_200 | ERROR_404 | ERROR_422,
@@ -88,3 +92,42 @@ async def list_workspace_guests(
     api_pagination.set_pagination(response=response, pagination=pagination)
 
     return guests
+
+
+##########################################################
+# delete workspace membership
+##########################################################
+
+
+@routes.workspaces_memberships.delete(
+    "/workspaces/{id}/memberships/{username}",
+    name="workspace.membership.delete",
+    summary="Delete workspace membership",
+    responses=ERROR_404 | ERROR_403,
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_workspace_membership(
+    request: AuthRequest,
+    id: B64UUID = Query(None, description="the workspace id (B64UUID)"),
+    username: str = Query(None, description="the membership username (str)"),
+) -> None:
+    """
+    Delete a workspace membership
+    """
+    membership = await get_workspace_membership_or_404(workspace_id=id, username=username)
+    await check_permissions(permissions=DELETE_WORKSPACE_MEMBERSHIP, user=request.user, obj=membership.workspace)
+
+    await memberships_services.delete_workspace_membership(membership=membership)
+
+
+################################################
+# misc: get workspace membership or 404
+################################################
+
+
+async def get_workspace_membership_or_404(workspace_id: UUID, username: str) -> WorkspaceMembership:
+    membership = await memberships_services.get_workspace_membership(workspace_id=workspace_id, username=username)
+    if membership is None:
+        raise ex.NotFoundError(f"User {username} is not a member of workspace {workspace_id}")
+
+    return membership

--- a/python/apps/taiga/src/taiga/workspaces/memberships/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/events/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.events import events_manager
+from taiga.workspaces.memberships.events.content import DeleteWorkspaceMembershipContent
+from taiga.workspaces.memberships.models import WorkspaceMembership
+
+DELETE_WORKSPACE_MEMBERSHIP = "workspacememberships.delete"
+
+
+async def emit_event_when_workspace_membership_is_deleted(membership: WorkspaceMembership) -> None:
+    await events_manager.publish_on_workspace_channel(
+        workspace=membership.workspace,
+        type=DELETE_WORKSPACE_MEMBERSHIP,
+        content=DeleteWorkspaceMembershipContent(membership=membership),
+    )
+
+    await events_manager.publish_on_user_channel(
+        user=membership.user,
+        type=DELETE_WORKSPACE_MEMBERSHIP,
+        content=DeleteWorkspaceMembershipContent(membership=membership),
+    )

--- a/python/apps/taiga/src/taiga/workspaces/memberships/events/content.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/events/content.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.base.serializers import BaseModel
+from taiga.workspaces.memberships.serializers import WorkspaceMembershipDeletedSerializer
+
+
+class DeleteWorkspaceMembershipContent(BaseModel):
+    membership: WorkspaceMembershipDeletedSerializer

--- a/python/apps/taiga/src/taiga/workspaces/memberships/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/serializers/__init__.py
@@ -11,6 +11,14 @@ from taiga.users.serializers.nested import UserNestedSerializer
 from taiga.workspaces.workspaces.serializers.nested import WorkspaceSmallNestedSerializer
 
 
+class WorkspaceMembershipDeletedSerializer(BaseModel):
+    user: UserNestedSerializer
+    workspace: WorkspaceSmallNestedSerializer
+
+    class Config:
+        orm_mode = True
+
+
 class WorkspaceMembershipDetailSerializer(BaseModel):
     user: UserNestedSerializer
     workspace: WorkspaceSmallNestedSerializer

--- a/python/apps/taiga/src/taiga/workspaces/memberships/services/exceptions.py
+++ b/python/apps/taiga/src/taiga/workspaces/memberships/services/exceptions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.base.services.exceptions import TaigaServiceException
+
+
+class MembershipIsTheOnlyMemberError(TaigaServiceException):
+    ...

--- a/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_api.py
@@ -124,3 +124,38 @@ async def test_list_workspace_guests_not_a_member(client):
 
     response = client.get(f"/workspaces/{workspace.b64id}/guests")
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+
+
+##########################################################
+# DELETE /workspaces/<id>/memberships/<username>
+##########################################################
+
+
+async def test_delete_workspace_membership(client):
+    user = await f.create_user()
+    member = await f.create_user()
+    workspace = await f.create_workspace(created_by=user)
+    await f.create_workspace_membership(workspace=workspace, user=member)
+
+    client.login(user)
+    response = client.delete(f"/workspaces/{workspace.b64id}/memberships/{member.username}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
+
+
+async def test_delete_workspace_membership_no_permission(client):
+    user = await f.create_user()
+    member = await f.create_user()
+    workspace = await f.create_workspace(created_by=user)
+
+    client.login(member)
+    response = client.delete(f"/workspaces/{workspace.b64id}/memberships/{user.username}")
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+
+
+async def test_delete_workspace_membership_latest_membership(client):
+    user = await f.create_user()
+    workspace = await f.create_workspace(created_by=user)
+
+    client.login(user)
+    response = client.delete(f"/workspaces/{workspace.b64id}/memberships/{user.username}")
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.text

--- a/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/memberships/test_repositories.py
@@ -63,12 +63,38 @@ async def test_get_workspace_membership():
     assert membership.workspace == workspace
     assert membership.user == user
 
+    membership = await repositories.get_workspace_membership(
+        filters={"id": membership.id}, select_related=["workspace", "user"]
+    )
+    assert membership.workspace == workspace
+    assert membership.user == user
+
+    membership = await repositories.get_workspace_membership(
+        filters={"username": user.username}, select_related=["workspace", "user"]
+    )
+    assert membership.workspace == workspace
+    assert membership.user == user
+
 
 async def test_get_workspace_membership_none():
     membership = await repositories.get_workspace_membership(
         filters={"user_id": uuid.uuid1(), "workspace_id": uuid.uuid1()}
     )
     assert membership is None
+
+
+##########################################################
+# delete workspace memberships
+##########################################################
+
+
+async def test_delete_stories() -> None:
+    user = await f.create_user()
+    member = await f.create_user()
+    workspace = await f.create_workspace(created_by=user)
+    membership = await f.create_workspace_membership(workspace=workspace, user=member)
+    deleted = await repositories.delete_workspace_memberships(filters={"id": membership.id})
+    assert deleted == 1
 
 
 ##########################################################

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -398,6 +398,24 @@ Content for:
   }
   ```
 
+#### **workspacesmemberships.delete**
+
+It happens when a workspace membership is deleted
+
+Content for:
+- workspace channel:
+  ```
+  {
+      "membership": {... "workspace membership object" ...}
+  }
+  ```
+
+- user channel:
+  ```
+  {
+      "membership": {... "workspace membership object" ...}
+  }
+  ```
 
 #### **projects.delete**
 

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f9a39c2f-c4e8-4b0d-843e-9a66c311eea2",
+		"_postman_id": "e380526d-5d4e-43c5-a33a-f17a0d69587e",
 		"name": "taiga-next",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -36,7 +36,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"username\": \"1001user\",\n    \"password\": \"123123\"\n}"
+							"raw": "{\n    \"username\": \"1user\",\n    \"password\": \"123123\"\n}"
 						},
 						"url": {
 							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/auth/token",
@@ -760,7 +760,12 @@
 						}
 					},
 					"response": []
-				},
+				}
+			]
+		},
+		{
+			"name": "workspace memberships",
+			"item": [
 				{
 					"name": "workspace memberships",
 					"event": [
@@ -874,6 +879,46 @@
 									"key": "limit",
 									"value": "{{limit}}"
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete workspace membership",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/workspaces/{{ws-id}}/memberships/{{username}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"workspaces",
+								"{{ws-id}}",
+								"memberships",
+								"{{username}}"
 							]
 						}
 					},


### PR DESCRIPTION
![](https://media.giphy.com/media/CPJIuTa8kz1MQ/giphy.gif)

This PR:
- adds a new endpoint to remove a member from a workspace (permissions: IsWorkspaceAdmin)
- restriction: you cannot delete a member if it's the latest (if it were you)
- adds a minor fix in user/admin (needed for tests)
- adds a new router for "workspace/memberships" with all the endpoints grouped
- **note**: as this endpoint comes before invite/accept, creating a membership is not trivial, so I haven't added the e2e tests; there is a separate task for this, after including invite/accept.

How to test:
- [x] check the code
- [x] tests are green
- [x] open the admin and go to a ws detail (you can see the memberships)
- [x] login as the "created by" user
- [x] delete any of the memberships using the API, check the events
- [x] leave the "created by" user till the end, try then and should be an error
- [x] try to delete a non-existing membership
- [x] try to delete a membership without permissions
- [x] check swagger urls for ws/memberships
