### PR TITLE
feat(invitations): u#2049 t#3585 delete project invitation

### DIFF
--- a/python/apps/taiga/src/taiga/projects/invitations/repositories.py
+++ b/python/apps/taiga/src/taiga/projects/invitations/repositories.py
@@ -57,6 +57,7 @@ ProjectInvitationSelectRelated = list[
         "project",
         "role",
         "workspace",
+        "invited_by",
     ]
 ]
 
@@ -155,7 +156,7 @@ def get_project_invitations(
 
 
 ##########################################################
-# update invitations
+# update project invitations
 ##########################################################
 
 
@@ -176,6 +177,18 @@ def bulk_update_project_invitations(objs_to_update: list[ProjectInvitation], fie
 @sync_to_async
 def update_user_projects_invitations(user: User) -> None:
     ProjectInvitation.objects.filter(email=user.email).update(user=user)
+
+
+##########################################################
+# delete project invitation
+##########################################################
+
+
+@sync_to_async
+def delete_project_invitation(filters: ProjectInvitationFilters = {}) -> int:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    count, _ = qs.delete()
+    return count
 
 
 ##########################################################

--- a/python/apps/taiga/src/taiga/projects/memberships/repositories.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/repositories.py
@@ -154,12 +154,12 @@ def update_project_membership(membership: ProjectMembership, values: dict[str, A
 
 
 ##########################################################
-# delete project memberships
+# delete project membership
 ##########################################################
 
 
 @sync_to_async
-def delete_project_memberships(filters: ProjectMembershipFilters = {}) -> int:
+def delete_project_membership(filters: ProjectMembershipFilters = {}) -> int:
     qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
     count, _ = qs.delete()
     return count

--- a/python/apps/taiga/tests/integration/taiga/projects/invitations/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/projects/invitations/test_repositories.py
@@ -296,6 +296,25 @@ async def test_bulk_update_project_invitations():
 
 
 ##########################################################
+# delete_project_invitation
+##########################################################
+
+
+async def test_delete_project_invitation():
+    project = await f.create_project()
+    user = await f.create_user()
+    role = await f.create_project_role(project=project)
+    await f.create_project_invitation(
+        user=user, email=user.email, project=project, status=ProjectInvitationStatus.PENDING, role=role
+    )
+
+    deleted_invitation = await repositories.delete_project_invitation(
+        filters={"project_id": project.id, "username_or_email": user.email},
+    )
+    assert deleted_invitation == 1
+
+
+##########################################################
 # misc - get_total_project_invitations
 ##########################################################
 

--- a/python/apps/taiga/tests/integration/taiga/projects/memberships/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/projects/memberships/test_repositories.py
@@ -84,16 +84,16 @@ async def test_update_project_membership():
 
 
 ##########################################################
-# delete_project_memberships
+# delete_project_membership
 ##########################################################
 
 
-async def test_delete_project_memberships() -> None:
+async def test_delete_project_membership() -> None:
     project = await f.create_project()
     user = await f.create_user()
     role = await f.create_project_role(project=project)
     membership = await repositories.create_project_membership(user=user, project=project, role=role)
-    deleted = await repositories.delete_project_memberships(
+    deleted = await repositories.delete_project_membership(
         filters={"id": membership.id},
     )
     assert deleted == 1

--- a/python/apps/taiga/tests/unit/taiga/projects/memberships/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/memberships/test_services.py
@@ -186,15 +186,21 @@ async def test_delete_project_membership_ok():
         patch(
             "taiga.projects.memberships.services.story_assignments_repositories", autospec=True
         ) as fake_story_assignments_repository,
+        patch(
+            "taiga.projects.memberships.services.project_invitations_repositories", autospec=True
+        ) as fake_project_invitations_repository,
         patch("taiga.projects.memberships.services.memberships_events", autospec=True) as fake_membership_events,
     ):
-        fake_membership_repository.delete_project_memberships.return_value = 1
+        fake_membership_repository.delete_project_membership.return_value = 1
         await services.delete_project_membership(membership=membership)
-        fake_membership_repository.delete_project_memberships.assert_awaited_once_with(
+        fake_membership_repository.delete_project_membership.assert_awaited_once_with(
             filters={"id": membership.id},
         )
         fake_story_assignments_repository.delete_stories_assignments.assert_awaited_once_with(
             filters={"project_id": membership.project_id, "username": membership.user.username}
+        )
+        fake_project_invitations_repository.delete_project_invitation.assert_awaited_once_with(
+            filters={"project_id": membership.project_id, "username_or_email": membership.user.email}
         )
         fake_membership_events.emit_event_when_project_membership_is_deleted.assert_awaited_once_with(
             membership=membership


### PR DESCRIPTION
## Delete project invitation when delete project membership

![](https://media.giphy.com/media/2aIHx38CqsNQA/giphy.gif)

This PR:
- Delete project invitation when delete project membership
- Add "invited_by" in ProjectInvitationSelectRelated (yami's request)
- Fix  delete_project_membership in singular.

### How to test
- [x] Review code
- [x] Tests are green
- [x] Delete project membership and check that project invitation is deleted too.
