### PR TITLE
feat(search): add functionality to search workspace uers to invite

### DIFF
--- a/python/apps/taiga/src/taiga/projects/invitations/models.py
+++ b/python/apps/taiga/src/taiga/projects/invitations/models.py
@@ -51,7 +51,7 @@ class ProjectInvitation(models.BaseModel, CreatedAtMetaInfoMixin):
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
-        verbose_name="inviited by",
+        verbose_name="invited by",
     )
     num_emails_sent = models.IntegerField(default=1, null=False, blank=False, verbose_name="num emails sent")
     resent_at = models.DateTimeField(null=True, blank=True, verbose_name="resent at")

--- a/python/apps/taiga/src/taiga/users/services/__init__.py
+++ b/python/apps/taiga/src/taiga/users/services/__init__.py
@@ -186,13 +186,21 @@ async def list_paginated_users_by_text(
     limit: int,
     text: str | None = None,
     project_id: UUID | None = None,
+    workspace_id: UUID | None = None,
 ) -> tuple[Pagination, list[User]]:
 
-    total_users = await users_repositories.get_total_users_by_text(text_search=text, project_id=project_id)
-
-    users = await users_repositories.list_users_by_text(
-        text_search=text, project_id=project_id, offset=offset, limit=limit
-    )
+    if workspace_id:
+        total_users = await users_repositories.get_total_workspace_users_by_text(
+            text_search=text, workspace_id=workspace_id
+        )
+        users = await users_repositories.list_workspace_users_by_text(
+            text_search=text, workspace_id=workspace_id, offset=offset, limit=limit
+        )
+    else:
+        total_users = await users_repositories.get_total_project_users_by_text(text_search=text, project_id=project_id)
+        users = await users_repositories.list_project_users_by_text(
+            text_search=text, project_id=project_id, offset=offset, limit=limit
+        )
 
     pagination = Pagination(offset=offset, limit=limit, total=total_users)
 

--- a/python/apps/taiga/tests/integration/taiga/users/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/users/test_api.py
@@ -136,13 +136,14 @@ async def test_list_users_by_text_anonymous(client):
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
 
 
-async def test_list_users_by_text(client):
+async def test_list_project_users_by_text(client):
+    project = await f.create_project()
     user = await f.create_user()
     user2 = await f.create_user()
     client.login(user)
 
     text = user2.username
-    project_id = "6JgsbGyoEe2VExhWgGrI2w"
+    project_id = project.b64id
     offset = 0
     limit = 10
 
@@ -154,13 +155,33 @@ async def test_list_users_by_text(client):
     assert response.headers["Pagination-Total"] == "1"
 
 
+async def test_list_workspace_users_by_text(client):
+    workspace = await f.create_workspace()
+    user = await f.create_user()
+    user2 = await f.create_user()
+    client.login(user)
+
+    text = user2.username
+    workspace_id = workspace.b64id
+    offset = 0
+    limit = 10
+
+    response = client.get(f"/users/search?text={text}&workspace={workspace_id}&offset={offset}&limit={limit}")
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert len(response.json()) == 1
+    assert response.headers["Pagination-Offset"] == "0"
+    assert response.headers["Pagination-Limit"] == "10"
+    assert response.headers["Pagination-Total"] == "1"
+
+
 async def test_list_users_by_text_no_results(client):
+    project = await f.create_project()
     user = await f.create_user()
     await f.create_user()
     client.login(user)
 
     text = "noresults"
-    project_id = "6JgsbGyoEe2VExhWgGrI2w"
+    project_id = project.b64id
     offset = 0
     limit = 10
 

--- a/python/apps/taiga/tests/integration/taiga/users/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/users/test_repositories.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright (c) 2023-present Kaleidos INC
+from unittest import IsolatedAsyncioTestCase
 
 import pytest
 from asgiref.sync import sync_to_async
@@ -147,102 +148,173 @@ async def test_list_guests_in_workspace():
     assert member in users
 
 
-##########################################################
-# list_users_by_text
-##########################################################
+class ListUserByText(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.ws_pj_admin = await f.create_user(is_active=True, username="wsadmin", full_name="ws-pj-admin")
+        self.elettescar = await f.create_user(is_active=True, username="elettescar", full_name="Elettescar - ws member")
+        self.electra = await f.create_user(is_active=True, username="electra", full_name="Electra - pj member")
+        self.danvers = await f.create_user(is_active=True, username="danvers", full_name="Danvers elena")
+        await f.create_user(is_active=True, username="edanvers", full_name="Elena Danvers")
+        await f.create_user(is_active=True, username="elmary", full_name="Él Marinari")
+        self.storm = await f.create_user(is_active=True, username="storm", full_name="Storm Smith")
+        self.inactive_user = await f.create_user(is_active=False, username="inactive", full_name="Inactive User")
 
+        # elettescar is ws-member
+        self.workspace = await f.create_workspace(created_by=self.ws_pj_admin, color=2)
+        await f.create_workspace_membership(user=self.elettescar, workspace=self.workspace)
 
-async def test_list_users_by_text():
-    ws_pj_admin = await f.create_user(is_active=True, username="wsadmin", full_name="ws-pj-admin")
-    elettescar = await f.create_user(is_active=True, username="elettescar", full_name="Elettescar - ws member")
-    electra = await f.create_user(is_active=True, username="electra", full_name="Electra - pj member")
-    danvers = await f.create_user(is_active=True, username="danvers", full_name="Danvers elena")
-    await f.create_user(is_active=True, username="edanvers", full_name="Elena Danvers")
-    await f.create_user(is_active=True, username="elmary", full_name="Él Marinari")
-    storm = await f.create_user(is_active=True, username="storm", full_name="Storm Smith")
-    inactive_user = await f.create_user(is_active=False, username="inactive", full_name="Inactive User")
+        # electra is a pj-member (from the previous workspace)
+        self.project = await f.create_project(workspace=self.workspace, created_by=self.ws_pj_admin)
+        self.general_role = await f.create_project_role(project=self.project, is_admin=False)
+        await f.create_project_membership(user=self.electra, project=self.project, role=self.general_role)
 
-    # elettescar is ws-member
-    workspace = await f.create_workspace(created_by=ws_pj_admin, color=2)
-    await f.create_workspace_membership(user=elettescar, workspace=workspace)
+        # danvers has a pending invitation
+        await f.create_project_invitation(
+            email="danvers@email.com",
+            user=self.danvers,
+            project=self.project,
+            role=self.general_role,
+            status=ProjectInvitationStatus.PENDING,
+            invited_by=self.ws_pj_admin,
+        )
 
-    # electra is a pj-member (from the previous workspace)
-    project = await f.create_project(workspace=workspace, created_by=ws_pj_admin)
-    general_role = await f.create_project_role(project=project, is_admin=False)
-    await f.create_project_membership(user=electra, project=project, role=general_role)
+    ##########################################################
+    # list_project_users_by_text
+    ##########################################################
 
-    # danvers has a pending invitation
-    await f.create_project_invitation(
-        email="danvers@email.com",
-        user=danvers,
-        project=project,
-        role=general_role,
-        status=ProjectInvitationStatus.PENDING,
-        invited_by=ws_pj_admin,
-    )
+    async def test_list_project_users_no_filter(self):
+        # searching all but inactive or system users (no text or project specified).
+        # results returned by alphabetical order (full_name/username)
+        all_active_no_sys_users_result = await users_repositories.list_project_users_by_text()
+        assert len(all_active_no_sys_users_result) == 7
+        assert all_active_no_sys_users_result[0].full_name == "Danvers elena"
+        assert all_active_no_sys_users_result[1].full_name == "Electra - pj member"
+        assert all_active_no_sys_users_result[2].full_name == "Elena Danvers"
+        assert self.inactive_user not in all_active_no_sys_users_result
 
-    # searching all but inactive or system users (no text or project specified). Alphabetical order (full_name/username)
-    all_active_no_sys_users_result = await users_repositories.list_users_by_text()
-    assert len(all_active_no_sys_users_result) == 7
-    assert all_active_no_sys_users_result[0].full_name == "Danvers elena"
-    assert all_active_no_sys_users_result[1].full_name == "Electra - pj member"
-    assert all_active_no_sys_users_result[2].full_name == "Elena Danvers"
-    assert inactive_user not in all_active_no_sys_users_result
+    async def test_list_project_users_ordering(self):
+        # searching for project, no text search. Ordering by project closeness and alphabetically (full_name/username)
+        result = await users_repositories.list_project_users_by_text(project_id=self.project.id)
+        assert len(result) == 7
+        # pj members should be returned first (project closeness criteria)
+        assert result[0].full_name == "Electra - pj member"
+        assert result[0].user_is_member is True
+        assert result[0].user_has_pending_invitation is False
+        assert result[1].full_name == "ws-pj-admin"
+        assert result[1].user_is_member is True
+        assert result[1].user_has_pending_invitation is False
+        # ws members should be returned secondly
+        assert result[2].full_name == "Elettescar - ws member"
+        assert result[2].user_is_member is False
+        assert result[2].user_has_pending_invitation is False
+        # then the rest of users alphabetically
+        assert result[3].full_name == "Danvers elena"
+        assert result[3].user_is_member is False
+        assert result[3].user_has_pending_invitation is True
+        assert result[4].full_name == "Elena Danvers"
+        assert result[5].full_name == "Él Marinari"
+        assert result[6].full_name == "Storm Smith"
 
-    # searching for project, no text search. Ordering by project closeness and alphabetically (full_name/username)
-    search_by_text_no_pj_result = await users_repositories.list_users_by_text(project_id=project.id)
-    assert len(search_by_text_no_pj_result) == 7
-    # pj members should be returned first (project closeness criteria)
-    assert search_by_text_no_pj_result[0].full_name == "Electra - pj member"
-    assert search_by_text_no_pj_result[0].user_is_member is True
-    assert search_by_text_no_pj_result[0].user_has_pending_invitation is False
-    assert search_by_text_no_pj_result[1].full_name == "ws-pj-admin"
-    assert search_by_text_no_pj_result[1].user_is_member is True
-    assert search_by_text_no_pj_result[1].user_has_pending_invitation is False
-    # ws members should be returned secondly
-    assert search_by_text_no_pj_result[2].full_name == "Elettescar - ws member"
-    assert search_by_text_no_pj_result[2].user_is_member is False
-    assert search_by_text_no_pj_result[2].user_has_pending_invitation is False
-    # then the rest of users alphabetically
-    assert search_by_text_no_pj_result[3].full_name == "Danvers elena"
-    assert search_by_text_no_pj_result[3].user_is_member is False
-    assert search_by_text_no_pj_result[3].user_has_pending_invitation is True
-    assert search_by_text_no_pj_result[4].full_name == "Elena Danvers"
-    assert search_by_text_no_pj_result[5].full_name == "Él Marinari"
-    assert search_by_text_no_pj_result[6].full_name == "Storm Smith"
+        assert self.inactive_user not in result
 
-    assert inactive_user not in search_by_text_no_pj_result
+    async def test_list_project_users_by_text_lower_case(self):
+        # searching for a text containing several words in lower case
+        result = await users_repositories.list_project_users_by_text(text_search="storm smith")
+        assert len(result) == 1
+        assert result[0].full_name == "Storm Smith"
 
-    # searching for a text containing several words in lower case
-    search_by_text_spaces_result = await users_repositories.list_users_by_text(text_search="storm smith")
-    assert len(search_by_text_spaces_result) == 1
-    assert search_by_text_spaces_result[0].full_name == "Storm Smith"
+    async def test_list_project_users_by_text_special_chars(self):
+        # searching for texts containing special chars (and cause no exception)
+        result = await users_repositories.list_project_users_by_text(text_search="<")
+        assert len(result) == 0
 
-    # searching for texts containing special chars (and cause no exception)
-    search_by_special_chars = await users_repositories.list_users_by_text(text_search="<")
-    assert len(search_by_special_chars) == 0
+    async def test_list_project_users_text_weights(self):
+        # Paginated search according to search text weights.
+        # 1st order by project closeness (pj, ws, others), 2nd by text search order (rank, left match)
+        result = await users_repositories.list_project_users_by_text(
+            text_search="EL", project_id=self.project.id, offset=0, limit=4
+        )
+        assert len(result) == 4
+        # first result must be `electra` as a pj-member (no matter how low her rank is against other farther pj users)
+        assert result[0].full_name == "Electra - pj member"
+        # second result should be `elettescar` as ws-member matching the text
+        assert result[1].full_name == "Elettescar - ws member"
+        # then the rest of users alphabetically ordered by rank and alphabetically.
+        # first would be *Él* Marinari/*el*mary with the highest rank (0.6079)
+        assert result[2].full_name == "Él Marinari"
+        # then goes `Elena Danvers` with a tied second rank (0.3039) but her name starts with the searched text ('el')
+        assert result[3].full_name == "Elena Danvers"
+        # `Danvers Elena` has the same rank (0.3039) but his name doesn't start with 'el', so he's left outside from the
+        # results due to the pagination limit (4)
+        assert self.danvers not in result
+        assert self.inactive_user not in result
+        assert self.ws_pj_admin not in result
+        assert self.storm not in result
 
-    # Paginated search. Order first by project closeness (pj, ws, others), then by text search order (rank, left match)
-    search_by_text_no_pj_pagination_result = await users_repositories.list_users_by_text(
-        text_search="EL", project_id=project.id, offset=0, limit=4
-    )
+    ##########################################################
+    # list_workspace_users_by_text
+    ##########################################################
 
-    assert len(search_by_text_no_pj_pagination_result) == 4
-    # first result must be `electra` as a pj-member (no matter how low her rank is against other farther pj users)
-    assert search_by_text_no_pj_pagination_result[0].full_name == "Electra - pj member"
-    # second result should be `elettescar` as a ws-member (no matter how low her rank is against other farther-pj users)
-    assert search_by_text_no_pj_pagination_result[1].full_name == "Elettescar - ws member"
-    # then the rest of users alphabetically ordered by rank and alphabetically.
-    # first would be *Él* Marinari/*el*mary with the highest rank (0.6079)
-    assert search_by_text_no_pj_pagination_result[2].full_name == "Él Marinari"
-    # then goes `Elena Danvers` with a tied second rank (0.3039) but her name starts with the searched text ('el')
-    assert search_by_text_no_pj_pagination_result[3].full_name == "Elena Danvers"
-    # `Danvers Elena` has the same rank (0.3039) but his name doesn't start with 'el', so he's left outside from the
-    # results due to the pagination limit (4)
-    assert danvers not in search_by_text_no_pj_pagination_result
-    assert inactive_user not in search_by_text_no_pj_pagination_result
-    assert ws_pj_admin not in search_by_text_no_pj_pagination_result
-    assert storm not in search_by_text_no_pj_pagination_result
+    async def test_list_workspace_users_by_workspace(self):
+        # workspace search, no text search. Ordering by workspace closeness and alphabetically (full_name/username)
+        result = await users_repositories.list_workspace_users_by_text(workspace_id=self.workspace.id)
+        assert len(result) == 7
+        # ws members should be returned first (workspace closeness criteria)
+        assert result[0].full_name == "Elettescar - ws member"
+        assert result[0].user_is_member is True
+        assert result[0].user_has_pending_invitation is False
+        assert result[1].full_name == "ws-pj-admin"
+        assert result[1].user_is_member is True
+        assert result[1].user_has_pending_invitation is False
+        # any member of the workspace's projects should be returned secondly
+        assert result[2].full_name == "Electra - pj member"
+        assert result[2].user_is_member is False
+        assert result[2].user_has_pending_invitation is False
+        # then the rest of users alphabetically
+        assert result[3].full_name == "Danvers elena"
+        assert result[3].user_is_member is False
+        assert result[3].user_has_pending_invitation is False
+        assert result[4].full_name == "Elena Danvers"
+        assert result[5].full_name == "Él Marinari"
+        assert result[6].full_name == "Storm Smith"
+
+        assert self.inactive_user not in result
+
+    async def test_list_workspace_users_by_text_lower_case(self):
+        # searching for a text containing several words in lower case
+        result = await users_repositories.list_workspace_users_by_text(
+            text_search="storm smith", workspace_id=self.workspace.id
+        )
+        assert len(result) == 1
+        assert result[0].full_name == "Storm Smith"
+
+    async def test_list_workspace_users_by_text_special_chars(self):
+        # searching for texts containing special chars (and cause no exception)
+        result = await users_repositories.list_workspace_users_by_text(text_search="<", workspace_id=self.workspace.id)
+        assert len(result) == 0
+
+    async def test_list_workspace_users_text_weights(self):
+        # Paginated search according to search text weights.
+        # 1st order by workspace closeness (ws, ws'pj membership, others), 2nd by text search order (rank, left match)
+        result = await users_repositories.list_workspace_users_by_text(
+            text_search="EL", workspace_id=self.workspace.id, offset=0, limit=4
+        )
+        assert len(result) == 4
+        # first result must be 'elettescar' as the only ws-member matching the text
+        assert result[0].full_name == "Elettescar - ws member"
+        # second result should be `electra` as the only member of the workspace's projects matching the text
+        assert result[1].full_name == "Electra - pj member"
+        # then the rest of users alphabetically ordered by rank and alphabetically, always matching the text.
+        # first would be *Él* Marinari/*el*mary with the highest rank (0.6079)
+        assert result[2].full_name == "Él Marinari"
+        # then goes `Elena Danvers` with a tied second rank (0.3039) but her name starts with the searched text ('el')
+        assert result[3].full_name == "Elena Danvers"
+        # `Danvers Elena` has the same rank (0.3039) but his name doesn't start with 'el', so he's left outside from the
+        # results due to the pagination limit (4)
+        assert self.danvers not in result
+        assert self.inactive_user not in result
+        assert self.ws_pj_admin not in result
+        assert self.storm not in result
 
 
 ##########################################################

--- a/python/apps/taiga/tests/unit/taiga/users/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/users/test_services.py
@@ -454,19 +454,55 @@ async def test_list_users_as_dict_with_usernames():
 
 
 #####################################################################
-# list_paginated_usrs_by_text (search users)
+# list_paginated_users_by_text (search users)
 #####################################################################
 
 
-async def test_list_paginated_users_by_text_ok():
+async def test_list_paginated_project_users_by_text_ok():
     with (patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,):
-        fake_users_repo.list_users_by_text.return_value = []
+        fake_users_repo.get_total_project_users_by_text.return_value = 0
+        fake_users_repo.list_project_users_by_text.return_value = []
 
         pagination, users = await services.list_paginated_users_by_text(
             text="text", project_id="id", offset=9, limit=10
         )
 
-        fake_users_repo.list_users_by_text.assert_awaited_with(text_search="text", project_id="id", offset=9, limit=10)
+        fake_users_repo.get_total_project_users_by_text.assert_awaited_with(text_search="text", project_id="id")
+        fake_users_repo.list_project_users_by_text.assert_awaited_with(
+            text_search="text", project_id="id", offset=9, limit=10
+        )
+
+        assert users == []
+
+
+async def test_list_paginated_workspace_users_by_text_ok():
+    with (patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,):
+        fake_users_repo.get_total_workspace_users_by_text.return_value = 0
+        fake_users_repo.list_workspace_users_by_text.return_value = []
+
+        pagination, users = await services.list_paginated_users_by_text(
+            text="text", workspace_id="id", offset=9, limit=10
+        )
+
+        fake_users_repo.get_total_workspace_users_by_text.assert_awaited_with(text_search="text", workspace_id="id")
+        fake_users_repo.list_workspace_users_by_text.assert_awaited_with(
+            text_search="text", workspace_id="id", offset=9, limit=10
+        )
+
+        assert users == []
+
+
+async def test_list_paginated_default_project_users_by_text_ok():
+    with (patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,):
+        fake_users_repo.get_total_project_users_by_text.return_value = 0
+        fake_users_repo.list_project_users_by_text.return_value = []
+
+        pagination, users = await services.list_paginated_users_by_text(text="text", offset=9, limit=10)
+
+        fake_users_repo.get_total_project_users_by_text.assert_awaited_with(text_search="text", project_id=None)
+        fake_users_repo.list_project_users_by_text.assert_awaited_with(
+            text_search="text", project_id=None, offset=9, limit=10
+        )
 
         assert users == []
 

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "a79393ca-a6a5-40d1-a921-934ef215d0fa",
+		"_postman_id": "c6b8fa0a-3d8b-49ff-8f5e-8f4f1e1ad679",
 		"name": "taiga-next",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -331,6 +332,11 @@
 								{
 									"key": "limit",
 									"value": "{{limit}}"
+								},
+								{
+									"key": "workspace",
+									"value": "{{ws-id}}",
+									"disabled": true
 								}
 							]
 						}

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "1b5b7074-7e62-4728-9399-05fae0aa1461",
+		"_postman_id": "f884802f-642d-41f7-a417-6f372f87c2a8",
 		"name": "taiga-next e2e",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -808,6 +809,7 @@
 									"pm.test(\"Environment variable settings\", function () {",
 									"    pm.environment.set(\"auth_token\", pm.response.json().token);",
 									"    pm.environment.set(\"refresh_token\", pm.response.json().refresh);",
+									"    pm.environment.set(\"search-text\", pm.response.json().username);",
 									"});",
 									"",
 									"// Tests",
@@ -913,6 +915,162 @@
 							],
 							"path": [
 								"workspaces"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "N/A my.user",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"    pm.environment.set(\"search-text\", pm.response.json().username);",
+									"});",
+									"   ",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    // Validate response API fields",
+									"    pm.expect(jsonRes).to.have.property(\"username\");",
+									"    pm.expect(jsonRes).to.have.property(\"fullName\");",
+									"    pm.expect(jsonRes).to.have.property(\"email\");",
+									"    pm.expect(jsonRes).to.have.property(\"lang\");",
+									"    pm.expect(jsonRes).to.have.property(\"color\");",
+									"    // Validate we're not returning more fields than expected",
+									"    var numOfReturnedFields = Object.keys(jsonRes).length;",
+									"    pm.expect(numOfReturnedFields).to.equal(5);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/user",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"my",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200.users.search (by workspace)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"    pm.expect(jsonRes.length).to.be.equal(1);",
+									"",
+									"    for (const [i, user] of jsonRes.entries()) {      ",
+									" ",
+									"        pm.expect(user).to.have.property(\"username\");",
+									"        pm.expect(user).to.have.property(\"fullName\");",
+									"        pm.expect(user).to.have.property(\"color\");",
+									"        pm.expect(user).to.have.property(\"userIsMember\");",
+									"        pm.expect(user).to.have.property(\"userHasPendingInvitation\");",
+									"    }",
+									"});// Post-request execution tasks"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/users/search?text={{search-text}}&offset={{offset}}&limit={{limit}}&workspace={{ws-id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"users",
+								"search"
+							],
+							"query": [
+								{
+									"key": "text",
+									"value": "{{search-text}}"
+								},
+								{
+									"key": "project",
+									"value": "{{pj-id}}",
+									"disabled": true
+								},
+								{
+									"key": "offset",
+									"value": "{{offset}}"
+								},
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "workspace",
+									"value": "{{ws-id}}"
+								}
 							]
 						}
 					},
@@ -1586,6 +1744,99 @@
 							],
 							"path": [
 								"projects"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200.users.search (by project)",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"    pm.expect(jsonRes.length).to.be.equal(1);",
+									"",
+									"    for (const [i, user] of jsonRes.entries()) {      ",
+									" ",
+									"        pm.expect(user).to.have.property(\"username\");",
+									"        pm.expect(user).to.have.property(\"fullName\");",
+									"        pm.expect(user).to.have.property(\"color\");",
+									"        pm.expect(user).to.have.property(\"userIsMember\");",
+									"        pm.expect(user).to.have.property(\"userHasPendingInvitation\");",
+									"    }",
+									"});// Post-request execution tasks"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/users/search?text={{search-text}}&project={{pj-id}}&offset={{offset}}&limit={{limit}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"users",
+								"search"
+							],
+							"query": [
+								{
+									"key": "text",
+									"value": "{{search-text}}"
+								},
+								{
+									"key": "project",
+									"value": "{{pj-id}}"
+								},
+								{
+									"key": "offset",
+									"value": "{{offset}}"
+								},
+								{
+									"key": "limit",
+									"value": "{{limit}}"
+								},
+								{
+									"key": "workspace",
+									"value": "{{ws-id}}",
+									"disabled": true
+								}
 							]
 						}
 					},


### PR DESCRIPTION
This PR adds functionality to search users by their closeness to a workspace reusing the same `/users/search` endpoint. The previous functionality (searching users by a project) should behave the same.

![giph](https://media.giphy.com/media/l46Cq3dy04lgkRVOE/giphy.gif)

This PR also ...
- Refactors the search repositories methods now using a shared text search method
- Refactors the tests to reuse common data between user search by project and workspace
- Adds missing e2e tests to postman (search users by project)
- Fixes and improve swagger doc regarding user search


### What to test
- [x] check the code
- [x] Tests are green
- [x] Review and agree with the [openAPI doc](http://localhost:8000/api/v2/docs#/users/users_search_users_search_get)

If you prefer to use the front-end in another repository instance, you could use the branch `us/1593/task/3570/refactor-modal-invitations` and check the responses in the browser, trying to invite to a workspace.
![image](https://user-images.githubusercontent.com/4539017/234784204-d923a9e0-5529-42a5-9f4a-106f3804a1da.png)

Log in as the `userd0` and identify the ws-id of the workspace named "Projects" (it has two ws-members and people in their projects). 

Perform a search looking for workspace users without providing a project, with the text "user" and the previous workspace:
`GET 'http://localhost:8000/api/v2/users/search?offset=0&limit=100&workspace=Vk1Du...3LrLg'`
-  [x] Verify it first list the ws-members in 'alphabetical' order (weighed full text search in username/full_name fields) 
-  [x] Verify it secondly list the members of the workspace's projects in 'alphabetical' order
-  [x] Verify it then list the rest of the users following the same 'alphabetical' order

Perform the same previous search, narrowing the text to "userd2" :
`GET 'http://localhost:8000/api/v2/users/search?text=userd2&offset=0&limit=100&workspace=Vk1Du...3LrLg` 
- [x] Verify the same three previous checks

Perform the same previous search, without a text (unchecking it in Postman) :
` GET 'http://localhost:8000/api/v2/users/search?offset=0&limit=100&workspace=Vk1Du...3LrLg`
- [x] Verify the same three previous checks

--- 
- [x] Verify the offset and limit pagination works
- [x] Verify the response in the header returns the pagination info
- [x] Verify you get a 403 with no user logged in

Perform several text searches, looking for project users, without providing a workspace
- [x] The previous functionality should work the same remaining unaffected 