### PR TITLE
feat(users): u#1593 update ws invitations after user verification

### DIFF
--- a/python/apps/taiga/src/taiga/users/services/__init__.py
+++ b/python/apps/taiga/src/taiga/users/services/__init__.py
@@ -25,6 +25,7 @@ from taiga.users.serializers import VerificationInfoSerializer
 from taiga.users.serializers import services as serializers_services
 from taiga.users.services import exceptions as ex
 from taiga.users.tokens import ResetPasswordToken, VerifyUserToken
+from taiga.workspaces.invitations import services as workspaces_invitations_services
 
 #####################################################################
 # create user
@@ -124,6 +125,7 @@ async def verify_user_from_token(token: str) -> VerificationInfoSerializer:
 
     await verify_user(user=user)
     await invitations_services.update_user_projects_invitations(user=user)
+    await workspaces_invitations_services.update_user_workspaces_invitations(user=user)
 
     # Accept project invitation, if it exists and the user comes from the email's CTA. Errors will be ignored
     project_invitation_token = verify_token.get("project_invitation_token", None)

--- a/python/apps/taiga/src/taiga/workspaces/invitations/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/events/__init__.py
@@ -13,6 +13,7 @@ from taiga.workspaces.invitations.models import WorkspaceInvitation
 from taiga.workspaces.workspaces.models import Workspace
 
 CREATE_WORKSPACE_INVITATION = "workspaceinvitations.create"
+UPDATE_WORKSPACE_INVITATION = "workspaceinvitations.update"
 
 
 async def emit_event_when_workspace_invitations_are_created(
@@ -35,3 +36,15 @@ async def emit_event_when_workspace_invitations_are_created(
             workspace=workspace,
             type=CREATE_WORKSPACE_INVITATION,
         )
+
+
+async def emit_event_when_workspace_invitation_is_updated(invitation: WorkspaceInvitation) -> None:
+    await events_manager.publish_on_workspace_channel(
+        workspace=invitation.workspace,
+        type=UPDATE_WORKSPACE_INVITATION,
+    )
+
+
+async def emit_event_when_workspace_invitations_are_updated(invitations: list[WorkspaceInvitation]) -> None:
+    for invitation in invitations:
+        await emit_event_when_workspace_invitation_is_updated(invitation)

--- a/python/apps/taiga/src/taiga/workspaces/invitations/repositories.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/repositories.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from asgiref.sync import sync_to_async
 from taiga.base.db.models import Q, QuerySet
+from taiga.users.models import User
 from taiga.workspaces.invitations.choices import WorkspaceInvitationStatus
 from taiga.workspaces.invitations.models import WorkspaceInvitation
 
@@ -76,6 +77,27 @@ def create_workspace_invitations(
 
 
 ##########################################################
+# list workspace invitations
+##########################################################
+
+
+@sync_to_async
+def list_workspace_invitations(
+    filters: WorkspaceInvitationFilters = {},
+    offset: int | None = None,
+    limit: int | None = None,
+    select_related: WorkspaceInvitationSelectRelated = [],
+) -> list[WorkspaceInvitation]:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    qs = _apply_select_related_to_queryset(qs=qs, select_related=select_related)
+
+    if limit is not None and offset is not None:
+        limit += offset
+
+    return list(qs[offset:limit])
+
+
+##########################################################
 # get workspace invitation
 ##########################################################
 
@@ -101,3 +123,8 @@ def get_workspace_invitation(
 @sync_to_async
 def bulk_update_workspace_invitations(objs_to_update: list[WorkspaceInvitation], fields_to_update: list[str]) -> None:
     WorkspaceInvitation.objects.bulk_update(objs_to_update, fields_to_update)
+
+
+@sync_to_async
+def update_user_workspaces_invitations(user: User) -> None:
+    WorkspaceInvitation.objects.filter(email=user.email).update(user=user)

--- a/python/apps/taiga/src/taiga/workspaces/invitations/services/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/services/__init__.py
@@ -143,6 +143,20 @@ async def create_workspace_invitations(
 
 
 ##########################################################
+# update workspace invitations
+##########################################################
+
+
+async def update_user_workspaces_invitations(user: User) -> None:
+    await invitations_repositories.update_user_workspaces_invitations(user=user)
+    invitations = await invitations_repositories.list_workspace_invitations(
+        filters={"user": user, "status": WorkspaceInvitationStatus.PENDING},
+        select_related=["workspace"],
+    )
+    await invitations_events.emit_event_when_workspace_invitations_are_updated(invitations=invitations)
+
+
+##########################################################
 # send workspace invitation
 ##########################################################
 

--- a/python/apps/taiga/tests/integration/taiga/workspaces/invitations/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/invitations/test_repositories.py
@@ -12,7 +12,7 @@ from taiga.workspaces.invitations import repositories
 from taiga.workspaces.invitations.choices import WorkspaceInvitationStatus
 from tests.utils import factories as f
 
-pytestmark = pytest.mark.django_db
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 ##########################################################
@@ -42,6 +42,111 @@ async def test_create_workspace_invitations():
     response = await repositories.create_workspace_invitations(objs=objs)
 
     assert len(response) == 2
+
+
+##########################################################
+# list_workspace_invitations
+##########################################################
+
+
+async def test_list_workspace_invitations_all_pending_users():
+    workspace = await f.create_workspace()
+    user_a = await f.create_user(full_name="A", email="a@user.com")
+    user_b = await f.create_user(full_name="B", email="b@user.com")
+    email_a = user_a.email
+    email_b = user_b.email
+    email_x = "x@notauser.com"
+    email_y = "y@notauser.com"
+    email_z = "z@notauser.com"
+
+    await f.create_workspace_invitation(
+        email=email_a, user=user_a, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    await f.create_workspace_invitation(
+        email=email_b, user=user_b, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    await f.create_workspace_invitation(
+        email=email_z, user=None, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    await f.create_workspace_invitation(
+        email=email_x, user=None, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    await f.create_workspace_invitation(
+        email=email_y, user=None, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    user = await f.create_user()
+    await f.create_workspace_invitation(
+        email=user.email, user=user, workspace=workspace, status=WorkspaceInvitationStatus.ACCEPTED
+    )
+
+    response = await repositories.list_workspace_invitations(
+        filters={"workspace_id": workspace.id, "status": WorkspaceInvitationStatus.PENDING}, offset=0, limit=100
+    )
+    assert len(response) == 5
+    assert response[0].email == user_a.email
+    assert response[1].email == user_b.email
+    assert response[2].email == email_x
+    assert response[3].email == email_y
+    assert response[4].email == email_z
+
+
+async def test_list_workspace_invitations_single_pending_user():
+    workspace = await f.create_workspace()
+
+    user1 = await f.create_user(full_name="AAA")
+    await f.create_workspace_invitation(
+        email=user1.email, user=user1, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    await f.create_workspace_invitation(
+        email="non-existing@email.com",
+        user=None,
+        workspace=workspace,
+        status=WorkspaceInvitationStatus.PENDING,
+    )
+
+    response = await repositories.list_workspace_invitations(
+        filters={"workspace_id": workspace.id, "user": user1, "status": WorkspaceInvitationStatus.PENDING},
+        offset=0,
+        limit=100,
+    )
+    assert len(response) == 1
+    assert response[0].email == user1.email
+
+
+async def test_list_workspace_invitations_single_pending_non_existing_user():
+    workspace = await f.create_workspace()
+
+    non_existing_email = "non-existing@email.com"
+    await f.create_workspace_invitation(
+        email=non_existing_email, user=None, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+
+    invitations = await repositories.list_workspace_invitations(
+        filters={
+            "workspace_id": workspace.id,
+            "email": non_existing_email,
+            "status": WorkspaceInvitationStatus.PENDING,
+        },
+        offset=0,
+        limit=100,
+    )
+    assert len(invitations) == 1
+    assert invitations[0].email == non_existing_email
+
+
+async def test_list_workspace_invitations_all_accepted_users():
+    workspace = await f.create_workspace()
+
+    user1 = await f.create_user(full_name="AAA")
+    await f.create_workspace_invitation(
+        email=user1.email, user=user1, workspace=workspace, status=WorkspaceInvitationStatus.ACCEPTED
+    )
+
+    response = await repositories.list_workspace_invitations(
+        filters={"workspace_id": workspace.id, "status": WorkspaceInvitationStatus.ACCEPTED}, offset=0, limit=100
+    )
+    assert len(response) == 1
+    assert response[0].email == user1.email
 
 
 ##########################################################
@@ -157,3 +262,15 @@ async def test_bulk_update_workspace_invitations():
 
     updated_invitation2 = await repositories.get_workspace_invitation(filters={"id": invitation2.id})
     assert updated_invitation2.num_emails_sent == 3
+
+
+async def test_update_user_workspaces_invitations():
+    workspace = await f.create_workspace()
+    user = await f.create_user(email="some@email.com")
+    invitation = await f.create_workspace_invitation(workspace=workspace, email="some@email.com", user=None)
+    assert not invitation.user
+
+    await repositories.update_user_workspaces_invitations(user=user)
+
+    invitation = await repositories.get_workspace_invitation(filters={"id": invitation.id}, select_related=["user"])
+    assert invitation.user == user

--- a/python/apps/taiga/tests/unit/taiga/users/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/users/test_services.py
@@ -196,6 +196,7 @@ async def test_verify_user_ok_no_project_invitation_token():
         patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,
         patch("taiga.users.services.auth_services", autospec=True) as fake_auth_services,
         patch("taiga.users.services.invitations_services", autospec=True) as fake_invitations_services,
+        patch("taiga.users.services.workspaces_invitations_services", autospec=True) as fake_ws_invitations_services,
     ):
         fake_token = FakeVerifyUserToken()
         fake_token.object_data = object_data
@@ -212,6 +213,7 @@ async def test_verify_user_ok_no_project_invitation_token():
         fake_token.denylist.assert_awaited_once()
         fake_users_repo.get_user.assert_awaited_once_with(filters=object_data)
         fake_invitations_services.update_user_projects_invitations.assert_awaited_once_with(user=user)
+        fake_ws_invitations_services.update_user_workspaces_invitations.assert_awaited_once_with(user=user)
         fake_token.get.assert_called_with("accept_project_invitation", False)
         fake_invitations_services.accept_project_invitation_from_token.assert_not_awaited()
         fake_auth_services.create_auth_credentials.assert_awaited_once_with(user=user)
@@ -231,6 +233,7 @@ async def test_verify_user_ok_with_accepting_project_invitation_token():
         patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,
         patch("taiga.users.services.auth_services", autospec=True) as fake_auth_services,
         patch("taiga.users.services.invitations_services", autospec=True) as fake_invitations_services,
+        patch("taiga.users.services.workspaces_invitations_services", autospec=True) as fake_ws_invitations_services,
     ):
         fake_token = FakeVerifyUserToken()
         fake_token.object_data = object_data
@@ -248,6 +251,7 @@ async def test_verify_user_ok_with_accepting_project_invitation_token():
         fake_token.denylist.assert_awaited_once()
         fake_users_repo.get_user.assert_awaited_once_with(filters=object_data)
         fake_invitations_services.update_user_projects_invitations.assert_awaited_once_with(user=user)
+        fake_ws_invitations_services.update_user_workspaces_invitations.assert_awaited_once_with(user=user)
         fake_token.get.assert_called_with("accept_project_invitation", False)
         fake_invitations_services.accept_project_invitation_from_token.assert_awaited_once_with(
             token=project_invitation_token, user=user
@@ -268,6 +272,7 @@ async def test_verify_user_ok_without_accepting_project_invitation_token():
         patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,
         patch("taiga.users.services.auth_services", autospec=True) as fake_auth_services,
         patch("taiga.users.services.invitations_services", autospec=True) as fake_invitations_services,
+        patch("taiga.users.services.workspaces_invitations_services", autospec=True) as fake_ws_invitations_services,
     ):
         fake_token = FakeVerifyUserToken()
         fake_token.object_data = object_data
@@ -285,6 +290,7 @@ async def test_verify_user_ok_without_accepting_project_invitation_token():
         fake_token.denylist.assert_awaited_once()
         fake_users_repo.get_user.assert_awaited_once_with(filters=object_data)
         fake_invitations_services.update_user_projects_invitations.assert_awaited_once_with(user=user)
+        fake_ws_invitations_services.update_user_workspaces_invitations.assert_awaited_once_with(user=user)
         fake_token.get.assert_called_with("accept_project_invitation", False)
         not fake_invitations_services.accept_project_invitation_from_token.assert_awaited
         fake_auth_services.create_auth_credentials.assert_awaited_once_with(user=user)
@@ -355,6 +361,7 @@ async def test_verify_user_error_project_invitation_token(exception):
         patch("taiga.users.services.VerifyUserToken", autospec=True) as FakeVerifyUserToken,
         patch("taiga.users.services.users_repositories", autospec=True) as fake_users_repo,
         patch("taiga.users.services.invitations_services", autospec=True) as fake_invitations_services,
+        patch("taiga.users.services.workspaces_invitations_services", autospec=True),
         patch("taiga.users.services.auth_services", autospec=True) as fake_auth_services,
     ):
         fake_token = FakeVerifyUserToken()


### PR DESCRIPTION
![](https://media.giphy.com/media/FOG3rc0p9UGI0/giphy-downsized.gif)

This PR sets the user in all the workspaces invitations after a user verifies her account.

How to test:
- [x] check the code
- [x] tests are green
- [x] with postman, invite a nonexisting user to a workspace with its email - check the invitation in django admin
- [x] then, create an account for this email, and verify it
- [x] check the invitation has changed and now it's linked to a user
- [x] check the event is emited