### PR TITLE
feat(workspace-invitations): u#1593 list invitations endpoint

### DIFF
--- a/python/apps/taiga/src/taiga/workspaces/invitations/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/api/__init__.py
@@ -5,8 +5,11 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
-from fastapi import Query
-from taiga.base.api import AuthRequest, responses
+from fastapi import Depends, Query, Response
+from taiga.base.api import AuthRequest
+from taiga.base.api import pagination as api_pagination
+from taiga.base.api import responses
+from taiga.base.api.pagination import PaginationQuery
 from taiga.base.api.permissions import check_permissions
 from taiga.base.validators import B64UUID
 from taiga.exceptions.api.errors import ERROR_400, ERROR_403, ERROR_404, ERROR_422
@@ -14,11 +17,13 @@ from taiga.permissions import IsWorkspaceAdmin
 from taiga.routers import routes
 from taiga.workspaces.invitations import services as workspaces_invitations_services
 from taiga.workspaces.invitations.api.validators import WorkspaceInvitationsValidator
-from taiga.workspaces.invitations.serializers import CreateWorkspaceInvitationsSerializer
+from taiga.workspaces.invitations.models import WorkspaceInvitation
+from taiga.workspaces.invitations.serializers import CreateWorkspaceInvitationsSerializer, WorkspaceInvitationSerializer
 from taiga.workspaces.workspaces.api import get_workspace_or_404
 
 # PERMISSIONS
 CREATE_WORKSPACE_INVITATIONS = IsWorkspaceAdmin()
+LIST_WORKSPACE_INVITATIONS = IsWorkspaceAdmin()
 
 
 # HTTP 200 RESPONSES
@@ -50,3 +55,35 @@ async def create_workspace_invitations(
     return await workspaces_invitations_services.create_workspace_invitations(
         workspace=workspace, invitations=form.get_invitations_dict(), invited_by=request.user
     )
+
+
+##########################################################
+# list workspace invitations
+##########################################################
+
+
+@routes.workspaces_invitations.get(
+    "/workspaces/{id}/invitations",
+    name="workspace.invitations.list",
+    summary="List workspace pending invitations",
+    response_model=list[WorkspaceInvitationSerializer],
+    responses=ERROR_404 | ERROR_422 | ERROR_403,
+)
+async def list_workspace_invitations(
+    request: AuthRequest,
+    response: Response,
+    pagination_params: PaginationQuery = Depends(),
+    id: B64UUID = Query(None, description="the workspace id (B64UUID)"),
+) -> list[WorkspaceInvitation]:
+    """
+    List (pending) workspace invitations
+    """
+    workspace = await get_workspace_or_404(id)
+    await check_permissions(permissions=LIST_WORKSPACE_INVITATIONS, user=request.user, obj=workspace)
+
+    pagination, invitations = await workspaces_invitations_services.list_paginated_pending_workspace_invitations(
+        workspace=workspace, offset=pagination_params.offset, limit=pagination_params.limit
+    )
+
+    api_pagination.set_pagination(response=response, pagination=pagination)
+    return invitations

--- a/python/apps/taiga/src/taiga/workspaces/invitations/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/serializers/__init__.py
@@ -4,12 +4,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright (c) 2023-present Kaleidos INC
+
+
 from typing import Any
 from uuid import UUID
 
 from pydantic import EmailStr, validator
 from taiga.base.serializers import BaseModel
 from taiga.users.serializers.nested import UserNestedSerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceSmallNestedSerializer
 
 
 class PrivateEmailWorkspaceInvitationSerializer(BaseModel):
@@ -32,6 +35,16 @@ class PrivateEmailWorkspaceInvitationSerializer(BaseModel):
 class CreateWorkspaceInvitationsSerializer(BaseModel):
     invitations: list[PrivateEmailWorkspaceInvitationSerializer]
     already_members: int
+
+    class Config:
+        orm_mode = True
+
+
+class WorkspaceInvitationSerializer(BaseModel):
+    id: UUID
+    workspace: WorkspaceSmallNestedSerializer
+    user: UserNestedSerializer | None
+    email: EmailStr
 
     class Config:
         orm_mode = True

--- a/python/apps/taiga/src/taiga/workspaces/invitations/services/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/services/__init__.py
@@ -7,6 +7,7 @@
 
 from typing import Any
 
+from taiga.base.api.pagination import Pagination
 from taiga.base.utils.datetime import aware_utcnow
 from taiga.base.utils.emails import is_email
 from taiga.conf import settings
@@ -140,6 +141,30 @@ async def create_workspace_invitations(
     return serializers_services.serialize_create_workspace_invitations(
         invitations=list(invitations_to_send_list), already_members=already_members
     )
+
+
+##########################################################
+# list workspace invitations
+##########################################################
+
+
+async def list_paginated_pending_workspace_invitations(
+    workspace: Workspace, offset: int, limit: int
+) -> tuple[Pagination, list[WorkspaceInvitation]]:
+    pagination = Pagination(offset=offset, limit=limit, total=0)
+
+    invitations = await invitations_repositories.list_workspace_invitations(
+        filters={"workspace_id": workspace.id, "status": WorkspaceInvitationStatus.PENDING},
+        select_related=["user", "workspace"],
+        offset=offset,
+        limit=limit,
+    )
+    total_invitations = await invitations_repositories.get_total_workspace_invitations(
+        filters={"workspace_id": workspace.id, "status": WorkspaceInvitationStatus.PENDING},
+    )
+
+    pagination.total = total_invitations
+    return pagination, invitations
 
 
 ##########################################################

--- a/python/apps/taiga/tests/integration/taiga/workspaces/invitations/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/invitations/test_repositories.py
@@ -241,7 +241,7 @@ async def get_workspace_invitation_by_id_not_found() -> None:
 
 
 ##########################################################
-# update_workspace_invitation
+# update_workspace_invitations
 ##########################################################
 
 
@@ -274,3 +274,36 @@ async def test_update_user_workspaces_invitations():
 
     invitation = await repositories.get_workspace_invitation(filters={"id": invitation.id}, select_related=["user"])
     assert invitation.user == user
+
+
+##########################################################
+# misc - get_total_workspace_invitations
+##########################################################
+
+
+async def test_get_total_workspace_invitations():
+    workspace = await f.create_workspace()
+
+    user1 = await f.create_user(full_name="AAA")
+    await f.create_workspace_invitation(
+        email=user1.email, user=user1, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    user2 = await f.create_user(full_name="BBB")
+    await f.create_workspace_invitation(
+        email=user2.email, user=user2, workspace=workspace, status=WorkspaceInvitationStatus.PENDING
+    )
+    await f.create_workspace_invitation(
+        email="non-existing@email.com",
+        user=None,
+        workspace=workspace,
+        status=WorkspaceInvitationStatus.PENDING,
+    )
+    user = await f.create_user()
+    await f.create_workspace_invitation(
+        email=user.email, user=user, workspace=workspace, status=WorkspaceInvitationStatus.ACCEPTED
+    )
+
+    response = await repositories.get_total_workspace_invitations(
+        filters={"workspace_id": workspace.id, "status": WorkspaceInvitationStatus.PENDING}
+    )
+    assert response == 3


### PR DESCRIPTION
![](https://media.giphy.com/media/3o6Yg9rDXHL8Zrdlza/giphy-downsized.gif)

This PR adds a new endpoint to list invitations for a workspace. It's essentially the same as projects-invitations except in this case only a WSAdmin may request this endpoint.

How to review:
- [x] tests are green
- [x] code is ok
- [x] you may create different invitations for a ws using django admin
- [x] using Postman or other preferred method, request as an admin the invitations for the ws
- [x] you may request invitations for a non-existing ws - 404
- [x] you may request invitations with a non-admin user - 403