### PR TITLE
U/3233/back leave project

### DIFF
--- a/python/apps/taiga/src/taiga/permissions/__init__.py
+++ b/python/apps/taiga/src/taiga/permissions/__init__.py
@@ -63,3 +63,10 @@ class IsWorkspaceAdmin(PermissionComponent):
         from taiga.permissions import services as permissions_services
 
         return await permissions_services.is_workspace_admin(user=user, obj=obj)
+
+
+class IsASelfRequest(PermissionComponent):
+    async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
+        from taiga.permissions import services as permissions_services
+
+        return await permissions_services.is_a_self_request(user=user, obj=obj)

--- a/python/apps/taiga/src/taiga/permissions/services.py
+++ b/python/apps/taiga/src/taiga/permissions/services.py
@@ -15,7 +15,7 @@ from taiga.projects.invitations.choices import ProjectInvitationStatus
 from taiga.projects.memberships import repositories as pj_memberships_repositories
 from taiga.projects.projects.models import Project
 from taiga.projects.roles import repositories as pj_roles_repositories
-from taiga.users.models import AnyUser
+from taiga.users.models import AnyUser, User
 from taiga.workspaces.memberships import repositories as workspace_memberships_repositories
 from taiga.workspaces.workspaces.models import Workspace
 
@@ -203,4 +203,16 @@ async def get_user_permissions_for_workspace(is_workspace_member: bool) -> list[
 async def is_view_story_permission_deleted(old_permissions: list[str], new_permissions: list[str]) -> bool:
     if "view_story" in old_permissions and "view_story" not in new_permissions:
         return True
+    return False
+
+
+async def is_a_self_request(user: AnyUser, obj: Any) -> bool:
+    if user.is_anonymous:
+        return False
+
+    if isinstance(obj, User):
+        return obj == user
+    elif obj and hasattr(obj, "user"):
+        return obj.user == user
+
     return False

--- a/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
@@ -15,7 +15,7 @@ from taiga.base.api.permissions import check_permissions
 from taiga.base.validators import B64UUID
 from taiga.exceptions import api as ex
 from taiga.exceptions.api.errors import ERROR_400, ERROR_403, ERROR_404, ERROR_422
-from taiga.permissions import CanViewProject, IsProjectAdmin
+from taiga.permissions import CanViewProject, IsASelfRequest, IsProjectAdmin
 from taiga.projects.memberships import services as memberships_services
 from taiga.projects.memberships.api.validators import ProjectMembershipValidator
 from taiga.projects.memberships.models import ProjectMembership
@@ -26,7 +26,7 @@ from taiga.routers import routes
 # PERMISSIONS
 LIST_PROJECT_MEMBERSHIPS = CanViewProject()
 UPDATE_PROJECT_MEMBERSHIP = IsProjectAdmin()
-DELETE_PROJECT_MEMBERSHIP = IsProjectAdmin()
+DELETE_PROJECT_MEMBERSHIP = IsProjectAdmin() | IsASelfRequest()
 
 
 ##########################################################

--- a/python/apps/taiga/tests/integration/taiga/projects/memberships/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/projects/memberships/test_api.py
@@ -158,7 +158,7 @@ async def test_delete_project_membership_without_permissions(client):
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
 
 
-async def test_delete_project_membership_ok(client):
+async def test_delete_project_membership_project_admin(client):
     project = await f.create_project()
     member = await f.create_user()
     general_member_role = await f.create_project_role(
@@ -169,5 +169,20 @@ async def test_delete_project_membership_ok(client):
     await f.create_project_membership(user=member, project=project, role=general_member_role)
 
     client.login(project.created_by)
+    response = client.delete(f"/projects/{project.b64id}/memberships/{member.username}")
+    assert response.status_code == status.HTTP_204_NO_CONTENT, response.text
+
+
+async def test_delete_project_membership_self_request(client):
+    project = await f.create_project()
+    member = await f.create_user()
+    general_member_role = await f.create_project_role(
+        project=project,
+        permissions=choices.ProjectPermissions.values,
+        is_admin=False,
+    )
+    await f.create_project_membership(user=member, project=project, role=general_member_role)
+
+    client.login(member)
     response = client.delete(f"/projects/{project.b64id}/memberships/{member.username}")
     assert response.status_code == status.HTTP_204_NO_CONTENT, response.text

--- a/python/apps/taiga/tests/unit/taiga/base/api/test_permissions.py
+++ b/python/apps/taiga/tests/unit/taiga/base/api/test_permissions.py
@@ -14,6 +14,7 @@ from taiga.permissions import (
     CanViewProject,
     DenyAll,
     HasPerm,
+    IsASelfRequest,
     IsAuthenticated,
     IsProjectAdmin,
     IsSuperUser,
@@ -119,6 +120,26 @@ async def test_check_permission_can_view_project():
     # user2 isn't pj-member
     with pytest.raises(ex.ForbiddenError):
         await check_permissions(permissions=permissions, user=user2, obj=project)
+
+
+async def test_check_permission_is_a_self_request():
+    user1 = f.build_user()
+    user2 = f.build_user()
+    permissions = IsASelfRequest()
+
+    # user1 and obj are the same user
+    assert await check_permissions(permissions=permissions, user=user1, obj=user1) is None
+
+    # user1 and obj are not the same user
+    with pytest.raises(ex.ForbiddenError):
+        await check_permissions(permissions=permissions, user=user2, obj=user1)
+
+    membership = f.build_project_membership(user=user1)
+    # user1 and obj.user are the same user
+    assert await check_permissions(permissions=permissions, user=user1, obj=membership) is None
+    # user1 and obj.user are not the same user
+    with pytest.raises(ex.ForbiddenError):
+        await check_permissions(permissions=permissions, user=user2, obj=membership)
 
 
 #######################################################

--- a/python/apps/taiga/tests/unit/taiga/permissions/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/permissions/test_services.py
@@ -356,3 +356,22 @@ async def test_is_view_story_permission_deleted_true():
     new_permissions = []
 
     assert await services.is_view_story_permission_deleted(old_permissions, new_permissions) is True
+
+
+#####################################################
+# is_a_self_request
+#####################################################
+
+
+async def test_is_a_self_request_false():
+    user = f.build_user()
+    membership = f.build_project_membership()
+
+    assert await services.is_a_self_request(user, membership) is False
+
+
+async def test_is_a_self_request_true():
+    user = f.build_user()
+    membership = f.build_project_membership(user=user)
+
+    assert await services.is_a_self_request(user, membership) is True


### PR DESCRIPTION
![](https://media.giphy.com/media/p6MZnLrgtnKeXndv7H/giphy.gif)

This PR enables that a user can leave a project. For this, the PR changes the permissions on the endpoint `DELETE /projects/{id}/memberships/{username}` so now it can be requested by a Project admin or the user herself.

There are two commits in the PR:
- one adding the permission "IsASelfRequest" that checks that the user is requesting something for herself. The name is not my favourite, but I didn't find a better one
- one commit applying this new permission to the delete pj membership endpoint

How to review:
- [x] check the code
- [x] tests are green
- [x] being a pj admin, call the endpoint for other person - OK
- [x] then for himself - OK
- [x] being a pj member, call the endpoint for other person - permission error
- [x] then for herself - OK