### PR TITLE
check incompatible permissions for comment_story

### DIFF
--- a/python/apps/taiga/src/taiga/permissions/validators/fields.py
+++ b/python/apps/taiga/src/taiga/permissions/validators/fields.py
@@ -40,4 +40,8 @@ def _permissions_are_compatible(permissions: list[str]) -> bool:
     if "view_story" not in permissions and set.intersection(set(permissions), choices.EditStoryPermissions):
         return False
 
+    # a user cannot have "comment_story" permissions if she has no "view_story" permission
+    if "comment_story" in permissions and "view_story" not in permissions:
+        return False
+
     return True

--- a/python/apps/taiga/tests/unit/taiga/permissions/test_validators.py
+++ b/python/apps/taiga/tests/unit/taiga/permissions/test_validators.py
@@ -24,7 +24,7 @@ class PermissionsValidator(BaseModel):
     [
         ([], []),
         (["comment_story", "view_story"], ["comment_story", "view_story"]),
-        (["view_story", "view_story"], ["view_story", "view_story"]),
+        (["view_story", "modify_story"], ["view_story", "modify_story"]),
     ],
 )
 def test_permissions_are_valid_and_compatible(permissions: list[str], result: list[str]):


### PR DESCRIPTION
![](https://media.giphy.com/media/3orif7DKcHLWR6GMIE/giphy.gif) 

This PR guarantees that a user cannot configure at the same time "not-view-story" and "can-comment-story" as both are incompatible. It also fixes a redundant test.

How to validate:
- [x] code is easy ;-)
- [x] tests are green
- [x] PUT /projects/{id}/public-permissions with both "view_story" and "comment_story" - OK
- [x] PUT /projects/{id}/public-permissions just with "comment_story" - ERROR incompatible permissions