### PR TITLE
chore(invitations): generalize is_spam for projects and workspaces

### DIFF
--- a/python/apps/taiga/src/taiga/commons/__init__.py
+++ b/python/apps/taiga/src/taiga/commons/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC

--- a/python/apps/taiga/src/taiga/commons/invitations.py
+++ b/python/apps/taiga/src/taiga/commons/invitations.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.base.utils.datetime import aware_utcnow
+from taiga.conf import settings
+from taiga.projects.invitations.models import ProjectInvitation
+from taiga.workspaces.invitations.models import WorkspaceInvitation
+
+
+def is_spam(invitation: ProjectInvitation | WorkspaceInvitation) -> bool:
+    last_send_at = invitation.resent_at if invitation.resent_at else invitation.created_at
+    time_since_last_send = int((aware_utcnow() - last_send_at).total_seconds() / 60)  # in minutes
+    return (
+        invitation.num_emails_sent == settings.INVITATION_RESEND_LIMIT  # max invitations emails already sent
+        or time_since_last_send < settings.INVITATION_RESEND_TIME  # too soon to send the invitation again
+    )

--- a/python/apps/taiga/src/taiga/conf/__init__.py
+++ b/python/apps/taiga/src/taiga/conf/__init__.py
@@ -75,14 +75,14 @@ class Settings(BaseSettings):
 
     # Workspaces
     WORKSPACE_INVITATION_LIFETIME: int = 4 * 24 * 60  # 4 * 24 * 60 minutes = 4 days
-    WORKSPACE_INVITATION_RESEND_LIMIT: int = 10
-    WORKSPACE_INVITATION_RESEND_TIME: int = 10  # 10 minutes
 
     # Projects
     PROJECT_INVITATION_LIFETIME: int = 4 * 24 * 60  # 4 * 24 * 60 minutes = 4 days
-    PROJECT_INVITATION_RESEND_LIMIT: int = 10
-    PROJECT_INVITATION_RESEND_TIME: int = 10  # 10 minutes
     DEFAULT_PROJECT_TEMPLATE: str = "kanban"
+
+    # Invitations
+    INVITATION_RESEND_LIMIT: int = 10
+    INVITATION_RESEND_TIME: int = 10  # 10 minutes
 
     # Tasks (linux crontab style)
     CLEAN_EXPIRED_TOKENS_CRON: str = "0 0 * * *"  # default: once a day

--- a/python/apps/taiga/tests/unit/taiga/projects/invitations/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/invitations/test_services.py
@@ -367,7 +367,7 @@ async def test_create_project_invitations_with_pending_invitations_time_spam(tqm
         patch("taiga.projects.invitations.services.invitations_repositories", autospec=True) as fake_invitations_repo,
         patch("taiga.projects.invitations.services.users_services", autospec=True) as fake_users_services,
         patch("taiga.projects.invitations.services.invitations_events", autospec=True) as fake_invitations_events,
-        override_settings({"PROJECT_INVITATION_RESEND_TIME": 10}),
+        override_settings({"INVITATION_RESEND_TIME": 10}),
     ):
         fake_pj_roles_services.list_project_roles_as_dict.return_value = {role2.slug: role2}
         fake_invitations_repo.get_project_invitation.return_value = invitation
@@ -440,7 +440,7 @@ async def test_create_project_invitations_with_revoked_invitations_time_spam(tqm
         patch("taiga.projects.invitations.services.invitations_repositories", autospec=True) as fake_invitations_repo,
         patch("taiga.projects.invitations.services.users_services", autospec=True) as fake_users_services,
         patch("taiga.projects.invitations.services.invitations_events", autospec=True) as fake_invitations_events,
-        override_settings({"PROJECT_INVITATION_RESEND_TIME": 10}),
+        override_settings({"INVITATION_RESEND_TIME": 10}),
     ):
         fake_pj_roles_services.list_project_roles_as_dict.return_value = {role2.slug: role2}
         fake_invitations_repo.get_project_invitation.return_value = invitation
@@ -987,7 +987,7 @@ async def test_resend_project_invitation_resent_after_create(override_settings) 
         patch(
             "taiga.projects.invitations.services.send_project_invitation_email", autospec=True
         ) as fake_send_project_invitation_email,
-        override_settings({"PROJECT_INVITATION_RESEND_TIME": 10}),
+        override_settings({"INVITATION_RESEND_TIME": 10}),
     ):
         await services.resend_project_invitation(invitation=invitation, resent_by=project.created_by)
         fake_invitations_repo.update_project_invitation.assert_not_awaited()

--- a/python/apps/taiga/tests/unit/taiga/workspaces/invitations/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/workspaces/invitations/test_services.py
@@ -90,7 +90,7 @@ async def test_create_workspace_invitations_with_pending_invitations_time_spam(t
         patch("taiga.workspaces.invitations.services.invitations_repositories", autospec=True) as fake_invitations_repo,
         patch("taiga.workspaces.invitations.services.users_services", autospec=True) as fake_users_services,
         patch("taiga.workspaces.invitations.services.invitations_events", autospec=True) as fake_invitations_events,
-        override_settings({"WORKSPACE_INVITATION_RESEND_TIME": 10}),
+        override_settings({"INVITATION_RESEND_TIME": 10}),
     ):
         fake_invitations_repo.get_workspace_invitation.return_value = invitation
         fake_users_services.list_users_emails_as_dict.return_value = {}


### PR DESCRIPTION
![](https://media.giphy.com/media/LRP0gJIfItRHyneGYH/giphy.gif)

This PR has a little refactor over "_is_spam" check:
- new module `commons` for Taiga common stuff
- both projects and workspaces use this new general check
- unify settings as well

How to review:
- [x] check the code
- [x] tests are green
- [x] just a refactor, nothing fancy or new