### PR TITLE
feat(comments): list story comments

### DIFF
--- a/python/apps/taiga/src/taiga/base/api/ordering.py
+++ b/python/apps/taiga/src/taiga/base/api/ordering.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from fastapi.params import Query
+from humps.main import camelize, decamelize
+from taiga.exceptions import api as ex
+
+ORDER_DESC = """
+List of fields to specify the ordering criteria. By default it will assume an ascending order, use the - sign
+for a descending order.
+
+Usage examples: `order=createdAt`, `order=createdAt&order=-text`
+"""
+
+
+class OrderQuery:
+    _allowed: list[str] = []
+    _default: list[str] = []
+
+    def __init__(self, allowed: list[str], default: list[str]) -> None:
+        self._allowed = allowed
+        self._default = default
+
+    def __call__(self, order: list[str] = Query([], description=ORDER_DESC)) -> list[str]:  # type: ignore
+        values: list[str] = list(map(decamelize, order)) if order else self._default  # type: ignore
+        if invalids := set(values).difference(set(self._allowed)):
+            raise ex.ValidationError(f"Invalid ordering fields: {', '.join(map(camelize, invalids))}")
+
+        return values

--- a/python/apps/taiga/src/taiga/base/sampledata/factories.py
+++ b/python/apps/taiga/src/taiga/base/sampledata/factories.py
@@ -14,10 +14,10 @@ from typing import Final
 from uuid import UUID
 
 from asgiref.sync import sync_to_async
+from django.db.models import Model
 from faker import Faker
 from fastapi import UploadFile
 from taiga.base.sampledata import constants
-from taiga.comments.mixins import CommentsMixin
 from taiga.comments.models import Comment
 from taiga.projects.invitations import repositories as pj_invitations_repositories
 from taiga.projects.invitations.choices import ProjectInvitationStatus
@@ -319,7 +319,7 @@ async def create_story_comments(
 def _create_comment_object(
     text: str,
     created_by: User,
-    object: CommentsMixin,
+    object: Model,
     created_at: datetime | None = None,
 ) -> Comment:
     return Comment(

--- a/python/apps/taiga/src/taiga/comments/repositories.py
+++ b/python/apps/taiga/src/taiga/comments/repositories.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from typing import Literal, TypedDict
+
+from asgiref.sync import sync_to_async
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Model
+from taiga.base.db.models import QuerySet
+from taiga.comments.models import Comment
+
+##########################################################
+# filters and querysets
+##########################################################
+
+
+DEFAULT_QUERYSET = Comment.objects.all()
+
+
+class CommentsFilters(TypedDict, total=False):
+    content_object: Model
+
+
+def _apply_filters_to_queryset(
+    qs: QuerySet[Comment],
+    filters: CommentsFilters = {},
+) -> QuerySet[Comment]:
+    filter_data = dict(filters.copy())
+
+    if "content_object" in filters:
+        content_object = filter_data.pop("content_object")
+        filter_data["object_content_type"] = ContentType.objects.get_for_model(content_object)  # type: ignore[arg-type]
+        filter_data["object_id"] = content_object.id  # type: ignore[attr-defined]
+
+    return qs.filter(**filter_data)
+
+
+CommentSelectRelated = list[
+    Literal[
+        "created_by",
+    ]
+]
+
+
+def _apply_select_related_to_queryset(
+    qs: QuerySet[Comment],
+    select_related: CommentSelectRelated = ["created_by"],
+) -> QuerySet[Comment]:
+    return qs.select_related(*select_related)
+
+
+CommentOrderBy = list[
+    Literal[
+        "created_at",
+        "-created_at",
+    ]
+]
+
+
+def _apply_order_by_to_queryset(
+    qs: QuerySet[Comment],
+    order_by: CommentOrderBy,
+) -> QuerySet[Comment]:
+    return qs.order_by(*order_by)
+
+
+##########################################################
+# list comments
+##########################################################
+
+
+@sync_to_async
+def list_comments(
+    filters: CommentsFilters = {},
+    select_related: CommentSelectRelated = [],
+    order_by: CommentOrderBy = ["-created_at"],
+    offset: int | None = None,
+    limit: int | None = None,
+) -> list[Comment]:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    qs = _apply_select_related_to_queryset(qs=qs, select_related=select_related)
+    qs = _apply_order_by_to_queryset(order_by=order_by, qs=qs)
+
+    if limit is not None and offset is not None:
+        limit += offset
+
+    return list(qs[offset:limit])
+
+
+##########################################################
+# misc
+##########################################################
+
+
+@sync_to_async
+def get_total_comments(filters: CommentsFilters = {}) -> int:
+    qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    return qs.count()

--- a/python/apps/taiga/src/taiga/comments/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/comments/serializers/__init__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from pydantic.schema import datetime
+from taiga.base.serializers import BaseModel
+from taiga.users.serializers.nested import UserNestedSerializer
+
+
+class CommentDetailSerializer(BaseModel):
+    text: str
+    created_at: datetime
+    created_by: UserNestedSerializer
+
+    class Config:
+        orm_mode = True

--- a/python/apps/taiga/src/taiga/comments/serializers/services.py
+++ b/python/apps/taiga/src/taiga/comments/serializers/services.py
@@ -4,17 +4,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright (c) 2023-present Kaleidos INC
-
-from taiga.base.db import models
 from taiga.comments.models import Comment
+from taiga.comments.serializers import CommentDetailSerializer
 
 
-class RelatedCommentsMixin(models.Model):
-    comments = models.GenericRelation(
-        Comment,
-        content_type_field="object_content_type",
-        object_id_field="object_id",
-    )
-
-    class Meta:
-        abstract = True
+def serialize_comment(comment: Comment) -> CommentDetailSerializer:
+    return CommentDetailSerializer.from_orm(comment)

--- a/python/apps/taiga/src/taiga/comments/services.py
+++ b/python/apps/taiga/src/taiga/comments/services.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+from django.db.models import Model
+from taiga.base.api import Pagination
+from taiga.comments import repositories as comment_repositories
+from taiga.comments.repositories import CommentOrderBy
+from taiga.comments.serializers import CommentDetailSerializer
+from taiga.comments.serializers import services as comments_serializers
+
+##########################################################
+# list comments
+##########################################################
+
+
+async def list_paginated_comments(
+    content_object: Model,
+    offset: int,
+    limit: int,
+    order_by: CommentOrderBy = [],
+) -> tuple[Pagination, list[CommentDetailSerializer]]:
+    filters = {"content_object": content_object}
+    comments = await comment_repositories.list_comments(
+        filters=filters,
+        select_related=["created_by"],
+        order_by=order_by,
+        offset=offset,
+        limit=limit,
+    )
+    serialized_comments = [comments_serializers.serialize_comment(c) for c in comments]
+
+    total_comments = await comment_repositories.get_total_comments(filters=filters)
+    pagination = Pagination(offset=offset, limit=limit, total=total_comments)
+
+    return pagination, serialized_comments

--- a/python/apps/taiga/src/taiga/exceptions/api/__init__.py
+++ b/python/apps/taiga/src/taiga/exceptions/api/__init__.py
@@ -75,3 +75,13 @@ class ForbiddenError(HTTPException):
 class NotFoundError(HTTPException):
     def __init__(self, msg: str = codes.EX_NOT_FOUND.msg):
         super().__init__(status_code=status.HTTP_404_NOT_FOUND, code=codes.EX_NOT_FOUND.code, msg=msg)
+
+
+##############################
+# HTTP 422: VALIDATION ERROR
+##############################
+
+
+class ValidationError(HTTPException):
+    def __init__(self, msg: str = codes.EX_VALIDATION_ERROR.msg):
+        super().__init__(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, code=codes.EX_VALIDATION_ERROR.code, msg=msg)

--- a/python/apps/taiga/src/taiga/routers/loader.py
+++ b/python/apps/taiga/src/taiga/routers/loader.py
@@ -20,6 +20,7 @@ from taiga.projects.roles import api as projects_roles_api  # noqa
 from taiga.routers import routes
 from taiga.routers.routes import tags_metadata
 from taiga.stories.assignments import api as stories_assignments_api  # noqa
+from taiga.stories.comments import api as stories_comments_api  # noqa
 from taiga.stories.mediafiles import api as stories_mediafiles_api  # noqa
 from taiga.stories.stories import api as stories_api  # noqa
 from taiga.system import api as system_api  # noqa
@@ -46,5 +47,6 @@ def load_routes(api: FastAPI) -> None:
     api.include_router(routes.unauth_projects_invitations)
     api.include_router(routes.projects_memberships)
     api.include_router(routes.stories)
+    api.include_router(routes.comments)
     api.include_router(routes.my)
     api.include_router(routes.system)

--- a/python/apps/taiga/src/taiga/routers/routes.py
+++ b/python/apps/taiga/src/taiga/routers/routes.py
@@ -100,6 +100,17 @@ tags_metadata.append(
     }
 )
 
+
+# /comments
+comments = AuthAPIRouter(tags=["comments"])
+tags_metadata.append(
+    {
+        "name": "comments",
+        "description": "Endpoint for comments.",
+    }
+)
+
+
 # /my
 my = AuthAPIRouter(tags=["my"])
 tags_metadata.append({"name": "my", "description": "Endpoints for logged-in user's resources."})

--- a/python/apps/taiga/src/taiga/stories/comments/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/comments/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC

--- a/python/apps/taiga/src/taiga/stories/comments/api.py
+++ b/python/apps/taiga/src/taiga/stories/comments/api.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from fastapi import Depends, Query, Response
+from taiga.base.api import AuthRequest
+from taiga.base.api import pagination as api_pagination
+from taiga.base.api import responses
+from taiga.base.api.pagination import PaginationQuery
+from taiga.base.api.permissions import check_permissions
+from taiga.base.validators import B64UUID
+from taiga.comments import services as comments_services
+from taiga.comments.serializers import CommentDetailSerializer
+from taiga.exceptions.api.errors import ERROR_403, ERROR_404, ERROR_422
+from taiga.permissions import HasPerm
+from taiga.routers import routes
+from taiga.stories.comments.validators import CommentOrderQuery
+from taiga.stories.stories.api import get_story_or_404
+
+# PERMISSIONS
+LIST_COMMENTS = HasPerm("view_story")
+
+# HTTP 200 RESPONSES
+LIST_COMMENTS_DETAIL_200 = responses.http_status_200(model=list[CommentDetailSerializer])
+
+
+##########################################################
+# list story comments
+##########################################################
+
+
+@routes.comments.get(
+    "/projects/{project_id}/stories/{ref}/comments",
+    name="project.story.comments.create",
+    summary="List story comments",
+    responses=LIST_COMMENTS_DETAIL_200 | ERROR_403 | ERROR_422 | ERROR_404,
+)
+async def list_comments(
+    request: AuthRequest,
+    response: Response,
+    order_params: CommentOrderQuery = Depends(),  # type: ignore
+    pagination_params: PaginationQuery = Depends(),
+    project_id: B64UUID = Query(None, description="the project id (B64UUID)"),
+    ref: int = Query(None, description="the unique story reference within a project (str)"),
+) -> list[CommentDetailSerializer]:
+    """
+    List the story comments
+    """
+
+    story = await get_story_or_404(project_id, ref)
+    await check_permissions(permissions=LIST_COMMENTS, user=request.user, obj=story)
+    pagination, comments = await comments_services.list_paginated_comments(
+        content_object=story,
+        offset=pagination_params.offset,
+        limit=pagination_params.limit,
+        order_by=order_params,
+    )
+    api_pagination.set_pagination(response=response, pagination=pagination)
+    return comments

--- a/python/apps/taiga/src/taiga/stories/comments/validators.py
+++ b/python/apps/taiga/src/taiga/stories/comments/validators.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from taiga.base.api.ordering import OrderQuery
+
+CommentOrderQuery = OrderQuery(
+    allowed=[
+        "created_at",
+        "-created_at",
+    ],
+    default=[
+        "-created_at",
+    ],
+)

--- a/python/apps/taiga/src/taiga/stories/stories/models.py
+++ b/python/apps/taiga/src/taiga/stories/stories/models.py
@@ -8,7 +8,7 @@
 from taiga.base.db import models
 from taiga.base.db.mixins import CreatedMetaInfoMixin, DescriptionUpdatedMetaInfoMixin, TitleUpdatedMetaInfoMixin
 from taiga.base.occ.models import VersionedMixin
-from taiga.comments.mixins import CommentsMixin
+from taiga.comments.mixins import RelatedCommentsMixin
 from taiga.mediafiles.mixins import RelatedMediafilesMixin
 from taiga.projects.references.mixins import ProjectReferenceMixin
 
@@ -21,7 +21,7 @@ class Story(
     TitleUpdatedMetaInfoMixin,
     DescriptionUpdatedMetaInfoMixin,
     RelatedMediafilesMixin,
-    CommentsMixin,
+    RelatedCommentsMixin,
 ):
     title = models.CharField(max_length=500, null=False, blank=False, verbose_name="title")
     description = models.TextField(null=True, blank=True, verbose_name="description")

--- a/python/apps/taiga/tests/integration/taiga/comments/__init__.py
+++ b/python/apps/taiga/tests/integration/taiga/comments/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC

--- a/python/apps/taiga/tests/integration/taiga/comments/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/comments/test_repositories.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+from unittest import IsolatedAsyncioTestCase
+
+import pytest
+from taiga.comments import repositories
+from tests.utils import factories as f
+
+pytestmark = pytest.mark.django_db
+
+
+##########################################################
+# list_story_comments
+##########################################################
+
+
+class ListStoryComments(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.user = await f.create_user()
+        self.story1 = await f.create_story()
+        self.story2 = await f.create_story()
+        self.comment11 = await f.create_story_comment(content_object=self.story1, created_by=self.user, text="11")
+        self.comment12 = await f.create_story_comment(content_object=self.story1, created_by=self.user, text="12")
+        self.comment2 = await f.create_story_comment(content_object=self.story2, created_by=self.user, text="13")
+
+    async def test_list_story_comments_by_story(self):
+        response = await repositories.list_comments(
+            filters={"content_object": self.story1},
+        )
+        assert len(response) == 2
+        assert self.comment11 in response
+        assert self.comment12 in response
+
+
+##########################################################
+# misc - get_total_story_comments
+##########################################################
+
+
+async def test_get_total_story_comments_ok():
+    story1 = await f.create_story()
+    story2 = await f.create_story()
+    await f.create_story_comment(content_object=story1)
+    await f.create_story_comment(content_object=story1)
+    await f.create_story_comment(content_object=story2)
+
+    response = await repositories.get_total_comments(filters={"content_object": story1})
+    assert response == 2

--- a/python/apps/taiga/tests/integration/taiga/stories/comments/__init__.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/comments/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC

--- a/python/apps/taiga/tests/integration/taiga/stories/comments/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/comments/test_api.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+import pytest
+from fastapi import status
+from tests.utils import factories as f
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+FULL_PERMISSIONS = {
+    "add_story",
+    "comment_story",
+    "delete_story",
+    "modify_story",
+    "view_story",
+}
+NO_ADD_STORY_PERMISSIONS = FULL_PERMISSIONS - {"add_story"}
+WRONG_ID = "wrong_id"
+WRONG_B64ID = "awu3KvlrEe2h_el7Ht7XHQ"
+WRONG_SLUG = "wrong_slug"
+WRONG_REF = 9999
+
+
+##########################################################
+# LIST projects/<id>/stories/<ref>/comments
+##########################################################
+
+
+async def test_list_story_comments_200_min_params(client):
+    project = await f.create_project()
+    story = await f.create_story(project=project)
+    await f.create_story_comment(content_object=story, created_by=story.project.created_by, text="comment")
+
+    client.login(story.project.created_by)
+    response = client.get(f"/projects/{story.project.b64id}/stories/{story.ref}/comments")
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert len(response.json()) == 1
+
+
+async def test_list_story_comments_200_max_params(client):
+    project = await f.create_project()
+    story = await f.create_story(project=project)
+    await f.create_story_comment(content_object=story, created_by=story.project.created_by, text="comment")
+
+    offset = 0
+    limit = 1
+    order_params = "order=-createdAt"
+
+    client.login(story.project.created_by)
+    response = client.get(
+        f"/projects/{story.project.b64id}/stories/{story.ref}/comments?offset={offset}&limit={limit}&{order_params}"
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    assert len(response.json()) == 1
+    assert response.headers["Pagination-Offset"] == "0"
+    assert response.headers["Pagination-Limit"] == "1"
+    assert response.headers["Pagination-Total"] == "1"
+
+
+async def test_list_story_comments_404_project(client):
+    pj_admin = await f.create_user()
+
+    client.login(pj_admin)
+    response = client.get(f"/projects/{WRONG_B64ID}/stories/{WRONG_REF}/comments")
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+
+async def test_list_story_comments_404_story(client):
+    project = await f.create_project()
+
+    client.login(project.created_by)
+    response = client.get(f"/projects/{project.b64id}/stories/{WRONG_REF}/comments")
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+
+async def test_list_story_comments_422_story(client):
+    project = await f.create_project()
+
+    client.login(project.created_by)
+    response = client.get(f"/projects/{project.b64id}/stories/{WRONG_REF}/comments")
+    assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+
+async def test_list_story_comments_403(client):
+    not_allowed_user = await f.create_user()
+    project = await f.create_project()
+    story = await f.create_story(project=project)
+    await f.create_story_comment(content_object=story, created_by=story.project.created_by, text="comment")
+
+    client.login(not_allowed_user)
+    response = client.get(f"/projects/{story.project.b64id}/stories/{story.ref}/comments")
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text

--- a/python/apps/taiga/tests/unit/taiga/base/api/test_ordering.py
+++ b/python/apps/taiga/tests/unit/taiga/base/api/test_ordering.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+import pytest
+from humps import camelize, decamelize
+from taiga.base.api.ordering import OrderQuery
+from taiga.exceptions.api import ValidationError
+
+
+def test_validate_ordering_valid_params(client):
+    allowed_field_list = ["created_at", "-created_at", "text", "-text"]
+    default_ordering_list = ["-created_at"]
+    ordering_query = OrderQuery(allowed=allowed_field_list, default=default_ordering_list)
+
+    valid_field_list = ["-createdAt", "text"]
+    result = ordering_query.__call__(order=valid_field_list)
+
+    assert result == list(map(decamelize, valid_field_list))
+
+
+def test_validate_ordering_invalid_params(client):
+    allowed_field_list = ["created_at", "-created_at", "text", "-text"]
+    default_ordering_list = ["-created_at"]
+    ordering_query = OrderQuery(allowed=allowed_field_list, default=default_ordering_list)
+
+    invalid_field = "invalid_field"
+    ordering_params = allowed_field_list + [invalid_field]
+
+    with pytest.raises(ValidationError, match=f"Invalid ordering fields: {camelize(invalid_field)}"):
+        ordering_query.__call__(order=ordering_params)

--- a/python/apps/taiga/tests/unit/taiga/comments/__init__.py
+++ b/python/apps/taiga/tests/unit/taiga/comments/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC

--- a/python/apps/taiga/tests/unit/taiga/comments/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/comments/test_services.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from unittest.mock import patch
+
+import pytest
+from taiga.comments import services
+from tests.utils import factories as f
+
+pytestmark = pytest.mark.django_db
+
+
+#####################################################
+# list_comments
+#####################################################
+
+
+async def test_list_comments():
+    _story = await f.create_story()
+    _comment = await f.create_story_comment(content_object=_story)
+
+    _filters = {"content_object": _story}
+    _select_related = ["created_by"]
+    _order_by = (["-created_at"],)
+    _offset = (0,)
+    _limit = 100
+
+    with (
+        patch("taiga.comments.services.comment_repositories", autospec=True) as fake_comments_repository,
+        patch("taiga.comments.services.comments_serializers", autospec=True) as fake_comments_serializers,
+    ):
+
+        fake_comments_repository.list_comments.return_value = [_comment]
+        fake_comments_repository.get_total_comments.return_value = 1
+        await services.list_paginated_comments(content_object=_story, order_by=_order_by, offset=_offset, limit=_limit)
+        fake_comments_repository.list_comments.assert_awaited_once_with(
+            filters=_filters,
+            select_related=_select_related,
+            order_by=_order_by,
+            offset=_offset,
+            limit=_limit,
+        )
+        fake_comments_repository.get_total_comments.assert_awaited_once_with(filters=_filters)
+        fake_comments_serializers.serialize_comment.assert_called_once_with(comment=_comment)

--- a/python/apps/taiga/tests/utils/factories/__init__.py
+++ b/python/apps/taiga/tests/utils/factories/__init__.py
@@ -5,6 +5,7 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
+from .comments import StoryCommentFactory, build_story_comment, create_story_comment  # noqa
 from .files import (  # noqa
     build_binary_file,
     build_binary_fileio,

--- a/python/apps/taiga/tests/utils/factories/comments.py
+++ b/python/apps/taiga/tests/utils/factories/comments.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from asgiref.sync import sync_to_async
+
+from .base import Factory, factory
+
+####################################################
+# Story Comments
+####################################################
+
+
+class StoryCommentFactory(Factory):
+    text = factory.Sequence(lambda n: f"Comment {n}")
+    content_object = factory.SubFactory("tests.utils.factories.StoryFactory")
+    created_by = factory.SubFactory("tests.utils.factories.UserFactory")
+
+    class Meta:
+        model = "comments.Comment"
+
+
+@sync_to_async
+def create_story_comment(**kwargs):
+    return StoryCommentFactory.create(**kwargs)
+
+
+def build_story_comment(**kwargs):
+    return StoryCommentFactory.build(**kwargs)

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "b307885c-1fa4-4f1d-bc77-41053531753a",
+		"_postman_id": "70ad43bc-0496-49d5-8f46-465db3fc5e27",
 		"name": "taiga-next",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "3299216"
@@ -2394,6 +2394,73 @@
 								"{{pj-id}}",
 								"stories",
 								"{{story_ref}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "get story comments",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"   pm.environment.set(\"story_version\", pm.response.json().version);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/stories/{{story_ref}}/comments?order=-createdAt&order=-text&limit=100&offset=0",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"stories",
+								"{{story_ref}}",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "order",
+									"value": "-createdAt"
+								},
+								{
+									"key": "order",
+									"value": "-text"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								},
+								{
+									"key": "offset",
+									"value": "0"
+								}
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4be31002-31ca-4ca6-b563-17ac2f4a115b",
+		"_postman_id": "20f89f45-68f5-44df-b881-a094b50aca32",
 		"name": "taiga-next e2e",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "3299216"
@@ -3070,6 +3070,76 @@
 								"{{pj-id}}",
 								"stories",
 								"{{story_ref}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200.projects.{p}.stories.{ref}.comments",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    // TODO: Add checks here when the POST endpoint exists",
+									"    var jsonRes = pm.response.json();",
+									"    var numOfReturnedFields = Object.keys(jsonRes).length;",
+									"    pm.expect(numOfReturnedFields).to.equal(0);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/stories/{{story_ref}}/comments?order=-createdAt&limit=100&offset=0",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"stories",
+								"{{story_ref}}",
+								"comments"
+							],
+							"query": [
+								{
+									"key": "order",
+									"value": "-createdAt"
+								},
+								{
+									"key": "limit",
+									"value": "100"
+								},
+								{
+									"key": "offset",
+									"value": "0"
+								}
 							]
 						}
 					},


### PR DESCRIPTION
This PR adds the endpoint to list the comments for a Story: `GET projects/<id>/stories/<ref>/comments`

- It should be paginated, and accept a param to sort by newest/oldest comments according to the creation_date.
- It's been added a new group in OpenApi doc to group the comments entries (for stories and other model's contentTypes)

![gif](https://media.giphy.com/media/xUA7aNCph54MS9Xco8/giphy.gif)

### What to test

- [x] Check the code
- [x] Tests are green
- [x] Review the API doc (docs/redocs)

Ensure you have the last sample data in your db, and use the django admin to identify a story with some comments.

You may find useful this query to identify the most commented stories and the projects they belong to:
```sql
select pp."name", ss.description, ss.ref, count(cc.id) from comments_comment cc
join stories_story ss on ss.id = cc.object_id
join projects_project pp on pp.id = ss.project_id 
group by ss.id, pp.id
order by count(pp.id) desc
```

- [x] List the story comments with no further parameters, verifying the comments are ordered by its creation date, in descendant order
- [x] List the story comments changing the pagination `comments?limit=1&offset=1`
- [x] List the story comments changing the order criteria `comments?order=text&order=createdAt`
- [x] 422 Error. List the story comments changing an invalid field order `comments?order=invalidField` 
- [x] 404 Error with wrong project/story
- [x] 403 Forbidden without `HasPerm("view_story")`



