### PR TITLE
feat: u#233 add comments to story detail

### DIFF
--- a/javascript/apps/taiga-e2e/src/e2e/project/story-detail/story-detail-comments.cy.ts
+++ b/javascript/apps/taiga-e2e/src/e2e/project/story-detail/story-detail-comments.cy.ts
@@ -1,0 +1,96 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present Kaleidos INC
+ */
+
+import { randText } from '@ngneat/falso';
+import {
+  Project,
+  ProjectMockFactory,
+  Story,
+  WorkspaceMockFactory,
+} from '@taiga/data';
+import {
+  createFullProjectInWSRequest,
+  createStoryRequest,
+} from '@test/support/helpers/project.helpers';
+import { createWorkspaceRequest } from '@test/support/helpers/workspace.helpers';
+
+const workspace = WorkspaceMockFactory();
+const projectMock = ProjectMockFactory();
+
+describe('StoryDetail', () => {
+  let story!: Story;
+  let project!: Project;
+
+  before(() => {
+    cy.login();
+
+    createWorkspaceRequest(workspace.name)
+      .then((request) => {
+        void createFullProjectInWSRequest(
+          request.body.id,
+          projectMock.name
+        ).then((response) => {
+          project = response.body;
+
+          void createStoryRequest(
+            'main',
+            response.body.id,
+            {
+              title: 'test',
+            },
+            'new'
+          ).then((response) => {
+            story = response.body;
+          });
+        });
+      })
+      .catch(console.error);
+  });
+
+  beforeEach(() => {
+    cy.login();
+
+    cy.visit(`/project/${project.id}/${project.slug}/stories/${story.ref}`);
+  });
+
+  it('create comment && sort', () => {
+    // first comment
+    cy.getBySel('open-comment-input').click();
+
+    const newComment = randText();
+
+    cy.setEditorContent('comment', newComment);
+
+    cy.getBySel('comment-save').click();
+
+    // second comment
+    cy.getBySel('open-comment-input').click();
+
+    const newComment2 = randText();
+
+    cy.setEditorContent('comment', newComment2);
+
+    cy.getBySel('comment-save').click();
+
+    cy.getBySel('comment').should('have.length', 2);
+
+    cy.getBySel('comments-total').should('contain', '2');
+  });
+
+  it('sort comments', () => {
+    cy.getBySel('comment')
+      .first()
+      .then(($comments) => {
+        const firstComment = $comments.text();
+
+        cy.getBySel('sort-comments').click();
+
+        cy.getBySel('comment').last().should('contain', firstComment);
+      });
+  });
+});

--- a/javascript/apps/taiga/src/app/app-routing.module.ts
+++ b/javascript/apps/taiga/src/app/app-routing.module.ts
@@ -21,6 +21,30 @@ import { ProjectInvitationCTAGuard } from './modules/project/data-access/guards/
 import { ProjectInvitationGuard } from './modules/project/data-access/guards/project-invitation.guard';
 import { WorkspaceInvitationCTAGuard } from './modules/workspace/feature-detail/guards/workspace-invitation-cta.guard';
 
+function isViewSetterKanbaStory(
+  future: ActivatedRouteSnapshot,
+  curr: ActivatedRouteSnapshot
+) {
+  const story = ':slug/stories/:storyRef';
+  const kanban = ':slug/kanban';
+
+  const urls = [story, kanban];
+
+  const findUrl = (it: ActivatedRouteSnapshot): boolean => {
+    const finded = !!urls.find((url) => it.routeConfig?.path === url);
+
+    if (finded) {
+      return true;
+    } else if (it.parent) {
+      return findUrl(it.parent);
+    } else {
+      return false;
+    }
+  };
+
+  return findUrl(future) && findUrl(curr);
+}
+
 /*
 Add to your route if you want to control the if the component is reused in the same url:
 
@@ -41,6 +65,10 @@ export class CustomReuseStrategy extends BaseRouteReuseStrategy {
     ) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return future.data.reuseComponent;
+    }
+
+    if (isViewSetterKanbaStory(future, curr)) {
+      return true;
     }
 
     return future.routeConfig === curr.routeConfig;

--- a/javascript/apps/taiga/src/app/modules/project/data-access/+state/actions/project.actions.ts
+++ b/javascript/apps/taiga/src/app/modules/project/data-access/+state/actions/project.actions.ts
@@ -123,5 +123,6 @@ export const projectEventActions = createActionGroup({
     }>(),
     'Remove Member': props<{ membership: Membership; workspace: string }>(),
     'Update Member': props<{ membership: Membership }>(),
+    'Create comment': props<{ storyRef: Story['ref']; projectId: string }>(),
   },
 });

--- a/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/story/kanban-story.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/feature-kanban/components/story/kanban-story.component.html
@@ -12,15 +12,14 @@ Copyright (c) 2023-present Kaleidos INC
       [class.has-focus]="cardHasFocus">
       <a
         class="story-title"
-        [href]="
-          '/project/' +
-          vm.project.id +
-          '/' +
-          vm.project.slug +
-          '/stories/' +
+        [routerLink]="[
+          '/project',
+          vm.project.id,
+          vm.project.slug,
+          'stories',
           story.ref
-        "
-        (click)="openStory($event)"
+        ]"
+        [state]="{ fromCard: true }"
         (focus)="handleCardFocus(true)"
         (blur)="handleCardFocus(false)">
         <div class="draggable-icon">

--- a/javascript/apps/taiga/src/app/modules/project/feature-navigation/components/project-navigation-menu/project-navigation-menu.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/feature-navigation/components/project-navigation-menu/project-navigation-menu.component.html
@@ -106,8 +106,7 @@ Copyright (c) 2023-present Kaleidos INC
               data-test="kanban-button"
               [attr.data-text]="t('commons.kanban')"
               (pointerenter)="popup($event, 'kanban')"
-              (pointerleave)="out()"
-              (click)="clearStoryDetail()">
+              (pointerleave)="out()">
               <a
                 @slideIn
                 (focus)="popup($event, 'kanban')"

--- a/javascript/apps/taiga/src/app/modules/project/feature-navigation/components/project-navigation-menu/project-navigation-menu.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-navigation/components/project-navigation-menu/project-navigation-menu.component.ts
@@ -22,7 +22,6 @@ import { Store } from '@ngrx/store';
 import { TuiSvgModule } from '@taiga-ui/core';
 import { Project } from '@taiga/data';
 import { AvatarModule } from '@taiga/ui/avatar';
-import { StoryDetailActions } from '~/app/modules/project/story-detail/data-access/+state/actions/story-detail.actions';
 import { CommonTemplateModule } from '~/app/shared/common-template.module';
 import { HasPermissionDirective } from '~/app/shared/directives/has-permissions/has-permission.directive';
 
@@ -215,9 +214,5 @@ export class ProjectNavigationMenuComponent {
     this.displaySettingsMenu.next();
     this.dialog.open = false;
     this.dialog.type = '';
-  }
-
-  public clearStoryDetail() {
-    this.store.dispatch(StoryDetailActions.leaveStoryDetail());
   }
 }

--- a/javascript/apps/taiga/src/app/modules/project/feature-shell/project-feature-shell-routing.module.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-shell/project-feature-shell-routing.module.ts
@@ -11,6 +11,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { ProjectAdminResolver } from './project-admin.resolver.service';
 import { ProjectFeatureShellResolverService } from './project-feature-shell-resolver.service';
 import { ProjectFeatureShellComponent } from './project-feature-shell.component';
+import { CanDeactivateGuard } from '~/app/shared/can-deactivate/can-deactivate.guard';
 
 const routes: Routes = [
   {
@@ -33,6 +34,7 @@ const routes: Routes = [
           import(
             '~/app/modules/project/feature-view-setter/project-feature-view-setter.module'
           ).then((m) => m.ProjectFeatureViewSetterModule),
+        canDeactivate: [CanDeactivateGuard],
       },
       {
         path: ':slug/stories/:storyRef',
@@ -40,6 +42,7 @@ const routes: Routes = [
           import(
             '~/app/modules/project/feature-view-setter/project-feature-view-setter.module'
           ).then((m) => m.ProjectFeatureViewSetterModule),
+        canDeactivate: [CanDeactivateGuard],
       },
       {
         path: 'stories/:storyRef',
@@ -47,6 +50,7 @@ const routes: Routes = [
           import(
             '~/app/modules/project/feature-view-setter/project-feature-view-setter.module'
           ).then((m) => m.ProjectFeatureViewSetterModule),
+        canDeactivate: [CanDeactivateGuard],
       },
       {
         path: ':slug/settings',

--- a/javascript/apps/taiga/src/app/modules/project/feature-view-setter/project-feature-view-setter.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/feature-view-setter/project-feature-view-setter.component.html
@@ -5,15 +5,16 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 Copyright (c) 2023-present Kaleidos INC
 -->
-
-<ng-container *ngIf="storyView$ | async as storyView">
-  <ng-container *ngIf="storyView !== 'full-view' || isKanban">
-    <ng-template #kanbanHost></ng-template>
-  </ng-container>
-  <ng-container *ngIf="selectStory$ | async as story">
-    <tg-project-feature-story-wrapper-full-view
-      *ngIf="
-        storyView === 'full-view' && story
-      "></tg-project-feature-story-wrapper-full-view>
+<ng-container *ngIf="model$ | async as vm">
+  <ng-container *ngIf="vm.storyView">
+    <ng-container *ngIf="vm.storyView !== 'full-view' || vm.isKanban">
+      <ng-template #kanbanHost></ng-template>
+    </ng-container>
+    <ng-container *ngIf="vm.selectStory">
+      <tg-project-feature-story-wrapper-full-view
+        *ngIf="
+          vm.storyView === 'full-view' && !vm.isKanban
+        "></tg-project-feature-story-wrapper-full-view>
+    </ng-container>
   </ng-container>
 </ng-container>

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-description/story-detail-description.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-description/story-detail-description.component.html
@@ -16,6 +16,7 @@ Copyright (c) 2023-present Kaleidos INC
           [formGroup]="descriptionForm"
           (ngSubmit)="save()">
           <tg-editor
+            id="edit-description"
             [tgStoryDetailDescriptionSticky]="vm.editorReady"
             [field]="descriptionForm.get('description')!.value"
             [height]="descriptionHeight"

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-description/story-detail-description.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/components/story-detail-description/story-detail-description.component.ts
@@ -31,8 +31,6 @@ import { PermissionsService } from '~/app/services/permissions.service';
 import { LocalStorageService } from '~/app/shared/local-storage/local-storage.service';
 import { filterNil } from '~/app/shared/utils/operators';
 import { ProjectApiService } from '@taiga/api';
-import { EditorImageUploadService } from '~/app/shared/editor/editor-image-upload.service';
-import { StoryDetailDescriptionImageUploadService } from '~/app/modules/project/story-detail/components/story-detail-description/story-detail-description-image-upload.service';
 
 export interface StoryDetailDescriptionState {
   projectId: Project['id'];
@@ -53,13 +51,7 @@ export interface StoryDetailDescriptionState {
   templateUrl: './story-detail-description.component.html',
   styleUrls: ['./story-detail-description.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  providers: [
-    RxState,
-    {
-      provide: EditorImageUploadService,
-      useClass: StoryDetailDescriptionImageUploadService,
-    },
-  ],
+  providers: [RxState],
 })
 export class StoryDetailDescriptionComponent implements OnChanges, OnDestroy {
   @ViewChild('descriptionContent')

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/actions/story-detail.actions.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/actions/story-detail.actions.ts
@@ -16,6 +16,7 @@ import {
   StoryView,
   Workflow,
   UserComment,
+  User,
 } from '@taiga/data';
 import { OrderComments } from '~/app/shared/comments/comments.component';
 
@@ -61,6 +62,12 @@ export const StoryDetailActions = createActionGroup({
       storyRef: Story['ref'];
       projectId: Project['id'];
     }>(),
+    'New Comment': props<{
+      comment: string;
+      storyRef: Story['ref'];
+      projectId: Project['id'];
+      user: User;
+    }>(),
   },
 });
 
@@ -87,6 +94,17 @@ export const StoryDetailApiActions = createActionGroup({
       total: number;
       order: OrderComments;
       offset: number;
+    }>(),
+    'New Comment Success': props<{
+      comment: string;
+      storyRef: Story['ref'];
+      projectId: Project['id'];
+      user: User;
+    }>(),
+    'New Comment Error': props<{
+      comment: string;
+      storyRef: Story['ref'];
+      projectId: Project['id'];
     }>(),
   },
 });

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail-comments.effects.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail-comments.effects.ts
@@ -1,0 +1,151 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present Kaleidos INC
+ */
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Actions, concatLatestFrom, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { fetch, optimisticUpdate } from '@ngrx/router-store/data-persistence';
+import { ProjectApiService } from '@taiga/api';
+import { exhaustMap, filter, map } from 'rxjs';
+import { AppService } from '~/app/services/app.service';
+import {
+  StoryDetailActions,
+  StoryDetailApiActions,
+} from '../actions/story-detail.actions';
+import { storyDetailFeature } from '../reducers/story-detail.reducer';
+import { selectUser } from '~/app/modules/auth/data-access/+state/selectors/auth.selectors';
+import { filterNil } from '~/app/shared/utils/operators';
+import { projectEventActions } from '~/app/modules/project/data-access/+state/actions/project.actions';
+
+@Injectable()
+export class StoryDetailCommentsEffects {
+  public redirectToFetchComments$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(StoryDetailActions.initStory, StoryDetailActions.nextCommentPage),
+      concatLatestFrom(() => [
+        this.store
+          .select(storyDetailFeature.selectComments)
+          .pipe(map((comments) => comments?.length ?? 0)),
+        this.store.select(storyDetailFeature.selectCommentsOrder),
+      ]),
+      map(([action, offset, order]) => {
+        return StoryDetailApiActions.fetchComments({
+          projectId: action.projectId,
+          storyRef: action.storyRef,
+          order,
+          offset,
+        });
+      })
+    );
+  });
+
+  public changeOrderComments$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(StoryDetailActions.changeOrderComments),
+      map((action) => {
+        return StoryDetailApiActions.fetchComments({
+          projectId: action.projectId,
+          storyRef: action.storyRef,
+          order: action.order,
+          offset: 0,
+        });
+      })
+    );
+  });
+
+  public fetchComments$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(StoryDetailApiActions.fetchComments),
+      fetch({
+        run: ({ projectId, storyRef, offset, order }) => {
+          return this.projectApiService
+            .getComments(projectId, storyRef, order, offset, 40)
+            .pipe(
+              map(({ comments, total }) => {
+                return StoryDetailApiActions.fetchCommentsSuccess({
+                  comments,
+                  total,
+                  order,
+                  offset,
+                });
+              })
+            );
+        },
+        onError: (_, httpResponse: HttpErrorResponse) => {
+          this.appService.toastGenericError(httpResponse);
+        },
+      })
+    );
+  });
+
+  public newComent$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(StoryDetailActions.newComment),
+      optimisticUpdate({
+        run: ({ storyRef, projectId, comment }) => {
+          return this.projectApiService
+            .newComment(projectId, storyRef, comment)
+            .pipe(
+              concatLatestFrom(() => [
+                this.store.select(selectUser).pipe(filterNil()),
+              ]),
+              map(([, user]) => {
+                return StoryDetailApiActions.newCommentSuccess({
+                  storyRef,
+                  projectId,
+                  comment,
+                  user,
+                });
+              })
+            );
+        },
+        undoAction: (action, httpResponse: HttpErrorResponse) => {
+          this.appService.toastGenericError(httpResponse);
+
+          return StoryDetailApiActions.newCommentError(action);
+        },
+      })
+    );
+  });
+
+  public fetchCommentsOnEvent$ = createEffect(() => {
+    return this.actions$.pipe(
+      ofType(projectEventActions.createComment),
+      concatLatestFrom(() => [
+        this.store.select(storyDetailFeature.selectStory).pipe(filterNil()),
+        this.store.select(storyDetailFeature.selectCommentsOrder),
+        this.store
+          .select(storyDetailFeature.selectComments)
+          .pipe(map((comments) => comments?.length ?? 0)),
+      ]),
+      filter(([{ storyRef }, story]) => story.ref === storyRef),
+      exhaustMap(([{ projectId }, story, order, offset]) => {
+        return this.projectApiService
+          .getComments(projectId, story.ref, order, 0, offset)
+          .pipe(
+            map(({ comments, total }) => {
+              return StoryDetailApiActions.fetchCommentsSuccess({
+                comments,
+                total,
+                order,
+                offset: 0,
+              });
+            })
+          );
+      })
+    );
+  });
+
+  constructor(
+    private store: Store,
+    private actions$: Actions,
+    private projectApiService: ProjectApiService,
+    private appService: AppService
+  ) {}
+}

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects-comments.spec.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects-comments.spec.ts
@@ -1,0 +1,228 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present Kaleidos INC
+ */
+
+import { Router } from '@angular/router';
+import { randUuid } from '@ngneat/falso';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { Action } from '@ngrx/store';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { ProjectApiService } from '@taiga/api';
+import {
+  StoryDetailMockFactory,
+  UserCommentMockFactory,
+  UserMockFactory,
+} from '@taiga/data';
+import { cold, hot } from 'jest-marbles';
+import { Observable } from 'rxjs';
+
+import { AppService } from '~/app/services/app.service';
+import { LocalStorageService } from '~/app/shared/local-storage/local-storage.service';
+import { getTranslocoModule } from '~/app/transloco/transloco-testing.module';
+import {
+  StoryDetailActions,
+  StoryDetailApiActions,
+} from '../actions/story-detail.actions';
+import { StoryDetailCommentsEffects } from './story-detail-comments.effects';
+import { storyDetailFeature } from '../reducers/story-detail.reducer';
+import { HttpErrorResponse } from '@angular/common/http';
+import { projectEventActions } from '~/app/modules/project/data-access/+state/actions/project.actions';
+import { selectUser } from '~/app/modules/auth/data-access/+state/selectors/auth.selectors';
+
+describe('StoryDetailEffects', () => {
+  let actions$: Observable<Action>;
+  let spectator: SpectatorService<StoryDetailCommentsEffects>;
+  let store: MockStore;
+
+  const createService = createServiceFactory({
+    service: StoryDetailCommentsEffects,
+    providers: [
+      provideMockActions(() => actions$),
+      provideMockStore({ initialState: {} }),
+    ],
+    imports: [getTranslocoModule()],
+    mocks: [ProjectApiService, AppService, Router, LocalStorageService],
+  });
+
+  beforeEach(() => {
+    spectator = createService();
+    store = spectator.inject(MockStore);
+  });
+  it('initStory - should redirect to fetchComments action', () => {
+    const effects = spectator.inject(StoryDetailCommentsEffects);
+    const story = StoryDetailMockFactory();
+    const projectId = randUuid();
+
+    const comments = [UserCommentMockFactory(), UserCommentMockFactory()];
+
+    store.overrideSelector(storyDetailFeature.selectCommentsOrder, 'createdAt');
+    store.overrideSelector(storyDetailFeature.selectComments, comments);
+
+    const action = StoryDetailActions.initStory({
+      projectId,
+      storyRef: story.ref,
+    });
+    const outcome = StoryDetailApiActions.fetchComments({
+      projectId,
+      storyRef: story.ref,
+      order: 'createdAt',
+      offset: 2,
+    });
+
+    actions$ = hot('-a', { a: action });
+    const expected = hot('-b', { b: outcome });
+
+    expect(effects.redirectToFetchComments$).toBeObservable(expected);
+  });
+
+  it('changeOrderComments - should redirect to fetchComments action', () => {
+    const effects = spectator.inject(StoryDetailCommentsEffects);
+    const story = StoryDetailMockFactory();
+    const projectId = randUuid();
+    const action = StoryDetailActions.changeOrderComments({
+      projectId,
+      storyRef: story.ref,
+      order: 'createdAt',
+    });
+    const outcome = StoryDetailApiActions.fetchComments({
+      projectId,
+      storyRef: story.ref,
+      order: 'createdAt',
+      offset: 0,
+    });
+
+    actions$ = hot('-a', { a: action });
+    const expected = hot('-b', { b: outcome });
+
+    expect(effects.changeOrderComments$).toBeObservable(expected);
+  });
+
+  it('should fetch comments successfully', () => {
+    const projectApiService = spectator.inject(ProjectApiService);
+    const story = StoryDetailMockFactory();
+    const projectId = randUuid();
+    const action = StoryDetailApiActions.fetchComments({
+      projectId,
+      storyRef: story.ref,
+      order: 'createdAt',
+      offset: 0,
+    });
+    const effects = spectator.inject(StoryDetailCommentsEffects);
+    const comments = [UserCommentMockFactory(), UserCommentMockFactory()];
+    const outcome = StoryDetailApiActions.fetchCommentsSuccess({
+      comments: comments,
+      total: comments.length,
+      order: 'createdAt',
+      offset: 0,
+    });
+
+    actions$ = hot('-a', { a: action });
+    const response = cold('-a|', { a: { comments, total: comments.length } });
+    const expected = cold('--b', { b: outcome });
+
+    projectApiService.getComments.mockReturnValue(response);
+
+    expect(effects.fetchComments$).toBeObservable(expected);
+  });
+
+  describe('newComment$', () => {
+    it('should dispatch newCommentSuccess action on successful new comment', () => {
+      const projectApiService = spectator.inject(ProjectApiService);
+      const effects = spectator.inject(StoryDetailCommentsEffects);
+      const comment = 'Test comment';
+      const storyRef = 123;
+      const projectId = 'testProject';
+      const user = UserMockFactory();
+
+      store.overrideSelector(selectUser, user);
+
+      const action = StoryDetailActions.newComment({
+        storyRef,
+        projectId,
+        comment,
+        user,
+      });
+      const completion = StoryDetailApiActions.newCommentSuccess({
+        storyRef,
+        projectId,
+        comment,
+        user,
+      });
+
+      actions$ = hot('-a', { a: action });
+      const response = cold('-b|', { b: null });
+      const expected = cold('--c', { c: completion });
+
+      projectApiService.newComment.mockReturnValue(response);
+
+      expect(effects.newComent$).toBeObservable(expected);
+    });
+
+    it('should dispatch newCommentError action on failed new comment', () => {
+      const projectApiService = spectator.inject(ProjectApiService);
+      const effects = spectator.inject(StoryDetailCommentsEffects);
+      const comment = 'Test comment';
+      const storyRef = 123;
+      const projectId = 'testProject';
+      const user = UserMockFactory();
+      store.overrideSelector(selectUser, user);
+
+      const action = StoryDetailActions.newComment({
+        storyRef,
+        projectId,
+        comment,
+        user,
+      });
+      const completion = StoryDetailApiActions.newCommentError(action);
+      const error = new HttpErrorResponse({});
+
+      actions$ = hot('-a', { a: action });
+      const response = cold('-#|', {}, error);
+      const expected = cold('--c', { c: completion });
+
+      projectApiService.newComment.mockReturnValue(response);
+
+      expect(effects.newComent$).toBeObservable(expected);
+    });
+  });
+
+  it('should fetch comments when a createComment event occurs', () => {
+    const projectApiService = spectator.inject(ProjectApiService);
+    const effects = spectator.inject(StoryDetailCommentsEffects);
+
+    const story = StoryDetailMockFactory();
+    const projectId = 'testProject';
+    const storyRef = story.ref;
+    const order = 'createdAt';
+    const offset = 0;
+    const total = 10;
+    const comments = Array(total).fill({});
+
+    store.overrideSelector(storyDetailFeature.selectStory, story);
+    store.overrideSelector(storyDetailFeature.selectCommentsOrder, order);
+
+    const action = projectEventActions.createComment({
+      projectId,
+      storyRef,
+    });
+    const completion = StoryDetailApiActions.fetchCommentsSuccess({
+      comments,
+      total,
+      order,
+      offset,
+    });
+
+    actions$ = hot('-a', { a: action });
+    const response = cold('-b|', { b: { comments, total } });
+    const expected = cold('--c', { c: completion });
+
+    projectApiService.getComments.mockReturnValue(response);
+
+    expect(effects.fetchCommentsOnEvent$).toBeObservable(expected);
+  });
+});

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.spec.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.spec.ts
@@ -16,7 +16,6 @@ import { ProjectApiService } from '@taiga/api';
 import {
   ProjectMockFactory,
   StoryDetailMockFactory,
-  UserCommentMockFactory,
   WorkflowMockFactory,
 } from '@taiga/data';
 import { cold, hot } from 'jest-marbles';
@@ -35,7 +34,6 @@ import {
   selectWorkflow,
 } from '../selectors/story-detail.selectors';
 import { StoryDetailEffects } from './story-detail.effects';
-import { storyDetailFeature } from '../reducers/story-detail.reducer';
 
 describe('StoryDetailEffects', () => {
   let actions$: Observable<Action>;
@@ -343,82 +341,5 @@ describe('StoryDetailEffects', () => {
         `/project/${project.id}/${project.slug}/kanban`,
       ]);
     });
-  });
-
-  it('initStory - should redirect to fetchComments action', () => {
-    const effects = spectator.inject(StoryDetailEffects);
-    const story = StoryDetailMockFactory();
-    const projectId = randUuid();
-
-    const comments = [UserCommentMockFactory(), UserCommentMockFactory()];
-
-    store.overrideSelector(storyDetailFeature.selectCommentsOrder, 'createdAt');
-    store.overrideSelector(storyDetailFeature.selectComments, comments);
-
-    const action = StoryDetailActions.initStory({
-      projectId,
-      storyRef: story.ref,
-    });
-    const outcome = StoryDetailApiActions.fetchComments({
-      projectId,
-      storyRef: story.ref,
-      order: 'createdAt',
-      offset: 2,
-    });
-
-    actions$ = hot('-a', { a: action });
-    const expected = hot('-b', { b: outcome });
-
-    expect(effects.redirectToFetchComments$).toBeObservable(expected);
-  });
-
-  it('changeOrderComments - should redirect to fetchComments action', () => {
-    const effects = spectator.inject(StoryDetailEffects);
-    const story = StoryDetailMockFactory();
-    const projectId = randUuid();
-    const action = StoryDetailActions.changeOrderComments({
-      projectId,
-      storyRef: story.ref,
-      order: 'createdAt',
-    });
-    const outcome = StoryDetailApiActions.fetchComments({
-      projectId,
-      storyRef: story.ref,
-      order: 'createdAt',
-      offset: 0,
-    });
-
-    actions$ = hot('-a', { a: action });
-    const expected = hot('-b', { b: outcome });
-
-    expect(effects.changeOrderComments$).toBeObservable(expected);
-  });
-
-  it('should fetch comments successfully', () => {
-    const projectApiService = spectator.inject(ProjectApiService);
-    const story = StoryDetailMockFactory();
-    const projectId = randUuid();
-    const action = StoryDetailApiActions.fetchComments({
-      projectId,
-      storyRef: story.ref,
-      order: 'createdAt',
-      offset: 0,
-    });
-    const effects = spectator.inject(StoryDetailEffects);
-    const comments = [UserCommentMockFactory(), UserCommentMockFactory()];
-    const outcome = StoryDetailApiActions.fetchCommentsSuccess({
-      comments: comments,
-      total: comments.length,
-      order: 'createdAt',
-      offset: 0,
-    });
-
-    actions$ = hot('-a', { a: action });
-    const response = cold('-a|', { a: { comments, total: comments.length } });
-    const expected = cold('--b', { b: outcome });
-
-    projectApiService.getComments.mockReturnValue(response);
-
-    expect(effects.fetchComments$).toBeObservable(expected);
   });
 });

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/effects/story-detail.effects.ts
@@ -29,7 +29,6 @@ import {
   selectStory,
   selectWorkflow,
 } from '../selectors/story-detail.selectors';
-import { storyDetailFeature } from '../reducers/story-detail.reducer';
 
 @Injectable()
 export class StoryDetailEffects {
@@ -252,65 +251,6 @@ export class StoryDetailEffects {
         },
         onError: (_, httpResponse: HttpErrorResponse) => {
           this.appService.toastSaveChangesError(httpResponse);
-        },
-      })
-    );
-  });
-
-  public redirectToFetchComments$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(StoryDetailActions.initStory, StoryDetailActions.nextCommentPage),
-      concatLatestFrom(() => [
-        this.store
-          .select(storyDetailFeature.selectComments)
-          .pipe(map((comments) => comments?.length ?? 0)),
-        this.store.select(storyDetailFeature.selectCommentsOrder),
-      ]),
-      map(([action, offset, order]) => {
-        return StoryDetailApiActions.fetchComments({
-          projectId: action.projectId,
-          storyRef: action.storyRef,
-          order,
-          offset,
-        });
-      })
-    );
-  });
-
-  public changeOrderComments$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(StoryDetailActions.changeOrderComments),
-      map((action) => {
-        return StoryDetailApiActions.fetchComments({
-          projectId: action.projectId,
-          storyRef: action.storyRef,
-          order: action.order,
-          offset: 0,
-        });
-      })
-    );
-  });
-
-  public fetchComments$ = createEffect(() => {
-    return this.actions$.pipe(
-      ofType(StoryDetailApiActions.fetchComments),
-      fetch({
-        run: ({ projectId, storyRef, offset, order }) => {
-          return this.projectApiService
-            .getComments(projectId, storyRef, order, offset, 40)
-            .pipe(
-              map(({ comments, total }) => {
-                return StoryDetailApiActions.fetchCommentsSuccess({
-                  comments,
-                  total,
-                  order,
-                  offset,
-                });
-              })
-            );
-        },
-        onError: (_, httpResponse: HttpErrorResponse) => {
-          this.appService.toastGenericError(httpResponse);
         },
       })
     );

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/reducers/story-detail.reducer.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/+state/reducers/story-detail.reducer.ts
@@ -213,6 +213,34 @@ export const reducer = createImmerReducer(
 
       return state;
     }
+  ),
+  on(
+    StoryDetailActions.newComment,
+    (state, { comment, user }): StoryDetailState => {
+      const newComment: UserComment = {
+        createdAt: new Date().toISOString(),
+        createdBy: {
+          fullName: user.fullName,
+          color: user.color,
+          username: user.username,
+        },
+        text: comment,
+      };
+
+      if (state.commentsOrder === '-createdAt') {
+        state.comments.unshift(newComment);
+      } else {
+        state.comments.push(newComment);
+      }
+
+      if (state.totalComments) {
+        state.totalComments++;
+      } else {
+        state.totalComments = 1;
+      }
+
+      return state;
+    }
   )
 );
 

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/story-detail-data-access.module.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/data-access/story-detail-data-access.module.ts
@@ -11,11 +11,12 @@ import { EffectsModule } from '@ngrx/effects';
 import { StoreModule } from '@ngrx/store';
 import { StoryDetailEffects } from './+state/effects/story-detail.effects';
 import { storyDetailFeature } from './+state/reducers/story-detail.reducer';
+import { StoryDetailCommentsEffects } from './+state/effects/story-detail-comments.effects';
 
 @NgModule({
   imports: [
     StoreModule.forFeature(storyDetailFeature),
-    EffectsModule.forFeature([StoryDetailEffects]),
+    EffectsModule.forFeature([StoryDetailEffects, StoryDetailCommentsEffects]),
   ],
 })
 export class DataAccessStoryDetailModule {}

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail-image-upload.service.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail-image-upload.service.ts
@@ -10,16 +10,14 @@ import { Injectable, inject } from '@angular/core';
 import { RxState } from '@rx-angular/state';
 import { ProjectApiService } from '@taiga/api';
 import { EditorImageUpload } from '~/app/shared/editor/editor-image-upload.service';
-import { StoryDetailDescriptionState } from './story-detail-description.component';
+import { StoryDetailState } from './story-detail.component';
 
 @Injectable({
   providedIn: 'root',
 })
-export class StoryDetailDescriptionImageUploadService
-  implements EditorImageUpload
-{
+export class StoryDetaiImageUploadService implements EditorImageUpload {
   public projectApiService = inject(ProjectApiService);
-  public state = inject<RxState<StoryDetailDescriptionState>>(RxState);
+  public state = inject<RxState<StoryDetailState>>(RxState);
 
   public imageUploadHandler(blobInfo: {
     filename: () => string;
@@ -30,7 +28,7 @@ export class StoryDetailDescriptionImageUploadService
     return new Promise((resolve) => {
       this.projectApiService
         .uploadStoriesMediafiles(
-          this.state.get('projectId'),
+          this.state.get('project').id,
           this.state.get('story').ref,
           [file]
         )

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.component.html
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.component.html
@@ -210,6 +210,7 @@ Copyright (c) 2023-present Kaleidos INC
             ">
             <div class="main-content-wrapper">
               <tui-scrollbar
+                tgCommentsAutoScroll
                 tgStoryCommentsPagination
                 [style.height.px]="columnHeight"
                 data-js="story-detail-scroll">
@@ -261,7 +262,8 @@ Copyright (c) 2023-present Kaleidos INC
                     [canComment]="vm.canComment"
                     [order]="vm.commentsOrder"
                     [loading]="vm.commentsLoading"
-                    (changeOrder)="changeCommentsOrder($event)"></tg-comments>
+                    (changeOrder)="changeCommentsOrder($event)"
+                    (comment)="onComment($event)"></tg-comments>
                 </div>
               </tui-scrollbar>
             </div>

--- a/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.module.ts
+++ b/javascript/apps/taiga/src/app/modules/project/story-detail/story-detail.module.ts
@@ -47,6 +47,7 @@ import { EditorComponent } from '~/app/shared/editor/editor.component';
 import { StoryDetailDescriptionStickyDirective } from './components/story-detail-description/story-detail-description-sticky.directive';
 import { CommentsComponent } from '~/app/shared/comments/comments.component';
 import { StoryCommentsPaginationDirective } from './directives/story-comments-pagination.directive';
+import { CommentsAutoScrollDirective } from '~/app/shared/comments/directives/comments-auto-scroll.directive';
 
 @NgModule({
   imports: [
@@ -84,6 +85,7 @@ import { StoryCommentsPaginationDirective } from './directives/story-comments-pa
     StoryDetailDescriptionStickyDirective,
     CommentsComponent,
     StoryCommentsPaginationDirective,
+    CommentsAutoScrollDirective,
   ],
   declarations: [
     StoryDetailComponent,

--- a/javascript/apps/taiga/src/app/shared/can-deactivate/can-deactivate.guard.ts
+++ b/javascript/apps/taiga/src/app/shared/can-deactivate/can-deactivate.guard.ts
@@ -1,0 +1,24 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present Kaleidos INC
+ */
+
+import { inject } from '@angular/core';
+import { CanDeactivateFn } from '@angular/router';
+import { Observable } from 'rxjs';
+import { CanDeactivateService } from './can-deactivate.service';
+
+export interface ComponentCanDeactivate {
+  canDeactivate: () => Observable<boolean>;
+}
+
+export const CanDeactivateGuard: CanDeactivateFn<
+  ComponentCanDeactivate
+> = () => {
+  const canDeactivateComponent = inject(CanDeactivateService);
+
+  return canDeactivateComponent.check();
+};

--- a/javascript/apps/taiga/src/app/shared/can-deactivate/can-deactivate.service.ts
+++ b/javascript/apps/taiga/src/app/shared/can-deactivate/can-deactivate.service.ts
@@ -1,0 +1,40 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present Kaleidos INC
+ */
+
+import { DestroyRef, Injectable } from '@angular/core';
+import { ComponentCanDeactivate } from './can-deactivate.guard';
+import { map, zip } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class CanDeactivateService {
+  private components: ComponentCanDeactivate[] = [];
+
+  public addComponent(component: ComponentCanDeactivate, destroy?: DestroyRef) {
+    this.components.push(component);
+
+    if (destroy) {
+      destroy.onDestroy(() => {
+        this.deleteComponent(component);
+      });
+    }
+  }
+
+  public deleteComponent(component: ComponentCanDeactivate) {
+    this.components = this.components.filter((it) => it !== component);
+  }
+
+  public check() {
+    if (this.components.length) {
+      return zip([...this.components.map((it) => it.canDeactivate())]).pipe(
+        map((results) => !results.some((it) => !it))
+      );
+    }
+
+    return true;
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/comments/comments.component.html
+++ b/javascript/apps/taiga/src/app/shared/comments/comments.component.html
@@ -12,6 +12,7 @@ Copyright (c) 2023-present Kaleidos INC
       {{ t('comments.title') }}
       <span
         *ngIf="total"
+        data-test="comments-total"
         class="total-comments"
         >({{ total }})</span
       >
@@ -37,6 +38,7 @@ Copyright (c) 2023-present Kaleidos INC
         type="button"
         class="sort"
         appearance="sort"
+        data-test="sort-comments"
         [attr.aria-label]="
           order === '-createdAt'
             ? t('comments.order.new')
@@ -55,13 +57,15 @@ Copyright (c) 2023-present Kaleidos INC
   </ng-container>
 
   <tg-comment-user-input
-    (click)="openCommentInput()"
-    *ngIf="canComment && order === '-createdAt'"></tg-comment-user-input>
+    *ngIf="(canComment && order === '-createdAt') || !total"
+    [order]="order"
+    (saved)="comment.next($event)"></tg-comment-user-input>
 
   <ng-container *ngIf="total">
     <div class="comment-list">
       <div
         *ngFor="let comment of comments; trackBy: trackIndex"
+        data-test="comment"
         class="comment">
         <div class="creation-info">
           <tg-user-avatar
@@ -103,8 +107,9 @@ Copyright (c) 2023-present Kaleidos INC
     </ng-container>
 
     <tg-comment-user-input
+      [order]="order"
+      (saved)="comment.next($event)"
       class="bottom"
-      (click)="openCommentInput()"
       *ngIf="canComment && order === 'createdAt'"></tg-comment-user-input>
   </ng-container>
   <div

--- a/javascript/apps/taiga/src/app/shared/comments/comments.component.ts
+++ b/javascript/apps/taiga/src/app/shared/comments/comments.component.ts
@@ -64,6 +64,7 @@ export class CommentsComponent {
   @Input({ required: true }) public loading!: boolean;
   @Input() public canComment = false;
   @Output() public changeOrder = new EventEmitter<OrderComments>();
+  @Output() public comment = new EventEmitter<string>();
 
   public localStorageService = inject(LocalStorageService);
 
@@ -73,16 +74,6 @@ export class CommentsComponent {
     this.localStorageService.set('comments_order', newOrder);
 
     this.changeOrder.emit(newOrder);
-  }
-
-  public openCommentInput(): void {
-    alert(
-      `
-    (\\(\\
-    ( -.-) "Work in progress"
-    o_(")(")
-    `
-    );
   }
 
   public trackIndex(index: number): number {

--- a/javascript/apps/taiga/src/app/shared/comments/components/comment-user-input/comment-user-input.component.css
+++ b/javascript/apps/taiga/src/app/shared/comments/components/comment-user-input/comment-user-input.component.css
@@ -23,4 +23,28 @@ Copyright (c) 2023-present Kaleidos INC
   inline-size: 100%;
   padding-inline-start: var(--spacing-16);
   text-align: start;
+
+  &:focus {
+    border-color: var(--color-secondary);
+  }
+}
+
+.field-actions {
+  display: flex;
+  gap: var(--spacing-8);
+  inset-block-end: var(--spacing-8);
+  inset-inline-end: var(--spacing-8);
+  position: absolute;
+}
+
+.editor {
+  box-shadow: 3px 4px 4px rgba(0, 138, 168, 0.15);
+  position: relative;
+
+  /* Prevent flicker on open */
+  visibility: hidden;
+
+  &.ready {
+    visibility: visible;
+  }
 }

--- a/javascript/apps/taiga/src/app/shared/comments/components/comment-user-input/comment-user-input.component.html
+++ b/javascript/apps/taiga/src/app/shared/comments/components/comment-user-input/comment-user-input.component.html
@@ -18,9 +18,53 @@ Copyright (c) 2023-present Kaleidos INC
       aria-hidden="true"></tg-user-avatar>
 
     <button
+      *ngIf="!vm.open"
+      data-test="open-comment-input"
+      tgRestoreFocusTarget="open-comment-input"
+      (click)="open()"
       type="button"
       class="open-comment-input">
       {{ t('comments.leave_comment') }}
     </button>
+
+    <div
+      (resized)="resizeEditor$.next()"
+      class="editor"
+      [class.ready]="vm.editorReady"
+      *ngIf="vm.open">
+      <tg-editor
+        id="comment"
+        tgRestoreFocus="open-comment-input"
+        field=""
+        [placeholder]="t('comments.leave_comment')"
+        (contentChange)="onCommentContentChange($event)"
+        (editorReady)="onInitEditor()"></tg-editor>
+
+      <div
+        class="field-actions"
+        *ngIf="vm.editorReady">
+        <button
+          (click)="cancel()"
+          data-test="comment-cancel"
+          tuiButton
+          type="button"
+          appearance="tertiary">
+          {{ t('commons.cancel') }}
+        </button>
+        <button
+          (click)="save()"
+          data-test="comment-save"
+          tuiButton
+          type="submit"
+          appearance="primary">
+          {{ t('comments.comment') }}
+        </button>
+      </div>
+    </div>
+
+    <tg-discard-changes-modal
+      [open]="vm.showConfirmationModal"
+      (discard)="discard$.next(true)"
+      (cancel)="discard$.next(false)"></tg-discard-changes-modal>
   </ng-container>
 </ng-container>

--- a/javascript/apps/taiga/src/app/shared/comments/components/comment-user-input/comment-user-input.component.ts
+++ b/javascript/apps/taiga/src/app/shared/comments/components/comment-user-input/comment-user-input.component.ts
@@ -6,35 +6,170 @@
  * Copyright (c) 2023-present Kaleidos INC
  */
 
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+  inject,
+} from '@angular/core';
 import { UserAvatarComponent } from '~/app/shared/user-avatar/user-avatar.component';
 import { Store } from '@ngrx/store';
 import { selectUser } from '~/app/modules/auth/data-access/+state/selectors/auth.selectors';
-import { filterNil } from '~/app/shared/utils/operators';
+import { filterFalsy, filterNil } from '~/app/shared/utils/operators';
 import { RxState } from '@rx-angular/state';
 import { User } from '@taiga/data';
-import { TranslocoModule } from '@ngneat/transloco';
+import { EditorComponent } from '~/app/shared/editor/editor.component';
+import { CommonTemplateModule } from '~/app/shared/common-template.module';
+import { DiscardChangesModalComponent } from '~/app/shared/discard-changes-modal/discard-changes-modal.component';
+import { ComponentCanDeactivate } from '~/app/shared/can-deactivate/can-deactivate.guard';
+import { CanDeactivateService } from '~/app/shared/can-deactivate/can-deactivate.service';
+import { Subject, filter, merge, of, take, throttleTime } from 'rxjs';
+import { CommentsAutoScrollDirective } from '~/app/shared/comments/directives/comments-auto-scroll.directive';
+import { OrderComments } from '~/app/shared/comments/comments.component';
+import { ResizedDirective } from '~/app/shared/resize/resize.directive';
+import { RestoreFocusDirective } from '~/app/shared/directives/restore-focus/restore-focus.directive';
+import { RestoreFocusTargetDirective } from '~/app/shared/directives/restore-focus/restore-focus-target.directive';
 
 interface CommentUserInputComponentState {
   user: User;
+  open: boolean;
+  editorReady: boolean;
+  comment: string;
+  showConfirmationModal: boolean;
 }
 
 @Component({
   selector: 'tg-comment-user-input',
   standalone: true,
-  imports: [CommonModule, UserAvatarComponent, TranslocoModule],
+  imports: [
+    CommonTemplateModule,
+    UserAvatarComponent,
+    EditorComponent,
+    DiscardChangesModalComponent,
+    ResizedDirective,
+    RestoreFocusDirective,
+    RestoreFocusTargetDirective,
+  ],
   templateUrl: './comment-user-input.component.html',
   styleUrls: ['./comment-user-input.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [RxState],
 })
-export class CommentUserInputComponent {
+export class CommentUserInputComponent implements ComponentCanDeactivate {
+  @Input({ required: true })
+  public order!: OrderComments;
+
+  @Output()
+  public saved = new EventEmitter<string>();
+
+  @HostListener('window:beforeunload')
+  public beforeunload() {
+    return !this.hasChanges();
+  }
+
+  public commentsAutoScrollDirective = inject(CommentsAutoScrollDirective, {
+    optional: true,
+  });
   public store = inject(Store);
-  public state = inject(RxState<CommentUserInputComponentState>);
+  public state = inject(RxState) as RxState<CommentUserInputComponentState>;
   public model$ = this.state.select();
+  public discard$ = new Subject<boolean>();
+  public resizeEditor$ = new Subject<void>();
 
   constructor() {
+    this.reset();
+
     this.state.connect('user', this.store.select(selectUser).pipe(filterNil()));
+
+    const canDeactivateService = inject(CanDeactivateService);
+    canDeactivateService.addComponent(this, inject(DestroyRef));
+
+    this.state.hold(this.discard$, (discard) => {
+      if (discard) {
+        this.discard();
+      } else {
+        this.keepEditing();
+      }
+    });
+
+    this.state.hold(
+      merge(
+        this.state.select('editorReady').pipe(filterFalsy()),
+        this.resizeEditor$
+      ).pipe(
+        filter(() => this.order === 'createdAt'),
+        throttleTime(100)
+      ),
+      () => {
+        this.commentsAutoScrollDirective?.scrollToBottom();
+      }
+    );
+  }
+
+  public canDeactivate() {
+    if (this.hasChanges()) {
+      this.state.set({ showConfirmationModal: true });
+
+      return this.discard$.pipe(take(1));
+    }
+
+    return of(true);
+  }
+
+  public open() {
+    this.state.set({
+      comment: '',
+      editorReady: false,
+      showConfirmationModal: false,
+      open: true,
+    });
+  }
+
+  public cancel() {
+    if (this.hasChanges()) {
+      this.state.set({ showConfirmationModal: true });
+      return false;
+    }
+
+    this.state.set({ open: false, editorReady: false });
+    return true;
+  }
+
+  public onCommentContentChange(comment: string) {
+    this.state.set({ comment });
+  }
+
+  public onInitEditor() {
+    this.state.set({ editorReady: true });
+  }
+
+  public hasChanges() {
+    return this.state.get('comment').trim().length > 0;
+  }
+
+  public save() {
+    this.saved.emit(this.state.get('comment'));
+    this.reset();
+  }
+
+  private discard() {
+    this.state.set({ showConfirmationModal: false, open: false });
+  }
+
+  private keepEditing() {
+    this.state.set({ showConfirmationModal: false });
+  }
+
+  private reset() {
+    this.state.set({
+      comment: '',
+      editorReady: false,
+      showConfirmationModal: false,
+      open: false,
+    });
   }
 }

--- a/javascript/apps/taiga/src/app/shared/comments/directives/comments-auto-scroll.directive.ts
+++ b/javascript/apps/taiga/src/app/shared/comments/directives/comments-auto-scroll.directive.ts
@@ -1,0 +1,33 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Copyright (c) 2023-present Kaleidos INC
+ */
+
+import { Directive, ElementRef, inject } from '@angular/core';
+
+/*
+  If the comment input is at the bottom of the page, the page must scroll to the bottom
+  because the actions buttons must be visible.
+
+  This happens every time the comment input is resized.
+*/
+
+@Directive({
+  // eslint-disable-next-line @angular-eslint/directive-selector
+  selector: '[tgCommentsAutoScroll]',
+  standalone: true,
+})
+export class CommentsAutoScrollDirective {
+  private el = inject(ElementRef) as ElementRef<HTMLElement>;
+
+  public get nativeElement() {
+    return this.el.nativeElement;
+  }
+
+  public scrollToBottom() {
+    this.nativeElement.scrollTop = this.nativeElement.scrollHeight;
+  }
+}

--- a/javascript/apps/taiga/src/app/shared/editor/editor.component.html
+++ b/javascript/apps/taiga/src/app/shared/editor/editor.component.html
@@ -9,6 +9,7 @@ Copyright (c) 2023-present Kaleidos INC
 <ng-container *ngIf="model$ | async as vm">
   <editor
     class="editor"
+    [id]="id"
     [(ngModel)]="field"
     (ngModelChange)="contentChange.next($event)"
     (onFocus)="onFocus()"
@@ -18,6 +19,7 @@ Copyright (c) 2023-present Kaleidos INC
       language: vm.lan.code,
       language_url: vm.lan.url,
       menubar: '',
+      placeholder: placeholder,
       height: height,
       toolbar:
         'blocks | bold italic underline strikethrough | bullist numlist | link image codesample| emoticons |  alignleft aligncenter alignright | outdent indent | forecolor backcolor removeformat | hr',

--- a/javascript/apps/taiga/src/app/shared/editor/editor.component.ts
+++ b/javascript/apps/taiga/src/app/shared/editor/editor.component.ts
@@ -51,10 +51,16 @@ interface EditorState {
 })
 export class EditorComponent {
   @Input({ required: true })
+  public id!: string;
+
+  @Input({ required: true })
   public field!: string | null;
 
   @Input()
   public height = 200;
+
+  @Input()
+  public placeholder = '';
 
   @Output()
   public contentChange = new EventEmitter<string>();

--- a/javascript/apps/taiga/src/assets/i18n/comments/en-US.json
+++ b/javascript/apps/taiga/src/assets/i18n/comments/en-US.json
@@ -2,6 +2,7 @@
   "title": "Comments",
   "leave_comment": "Leave a comment...",
   "no_comments": "There are no comments yet.",
+  "comment": "Comment",
   "order": {
     "new": "Newest first",
     "old": "Oldest first",

--- a/javascript/libs/api/src/lib/project/project-api.service.ts
+++ b/javascript/libs/api/src/lib/project/project-api.service.ts
@@ -546,4 +546,13 @@ export class ProjectApiService {
       status
     );
   }
+
+  public newComment(projectId: Project['id'], ref: Story['ref'], text: string) {
+    return this.http.post(
+      `${this.config.apiUrl}/projects/${projectId}/stories/${ref}/comments`,
+      {
+        text,
+      }
+    );
+  }
 }


### PR DESCRIPTION
Why is there so much refactoring in Kanban/story routing? I'm glad you asked. When you write a comment and then leave, a warning should appear. However, this doesn't function properly with location.go, location.replaceState etc, because these redirects occur outside the Angular context. So I've refactored to use [routerLink] and router.navigate and that wasn't easy with story and kanban sharing urls/space.

test with https://github.com/taigaio/taiga/pull/347