### PR TITLE
feat(status): create the endpoint to update the status name

### DIFF
--- a/python/apps/taiga/src/taiga/workflows/api/validators.py
+++ b/python/apps/taiga/src/taiga/workflows/api/validators.py
@@ -19,3 +19,7 @@ class Name(ConstrainedStr):
 class WorkflowStatusValidator(BaseModel):
     name: Name
     color: conint(gt=0, lt=9)  # type: ignore
+
+
+class UpdateWorkflowStatusValidator(BaseModel):
+    name: Name | None

--- a/python/apps/taiga/src/taiga/workflows/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/events/__init__.py
@@ -8,14 +8,12 @@
 from taiga.events import events_manager
 from taiga.projects.projects.models import Project
 from taiga.workflows.events.content import CreateWorkflowStatusContent
-from taiga.workflows.serializers import WorkflowStatusSerializer
+from taiga.workflows.models import WorkflowStatus
 
 CREATE_WORKFLOW_STATUS = "workflowstatuses.create"
 
 
-async def emit_event_when_workflow_status_is_created(
-    project: Project, workflow_status: WorkflowStatusSerializer
-) -> None:
+async def emit_event_when_workflow_status_is_created(project: Project, workflow_status: WorkflowStatus) -> None:
     await events_manager.publish_on_project_channel(
         project=project,
         type=CREATE_WORKFLOW_STATUS,

--- a/python/apps/taiga/src/taiga/workflows/repositories.py
+++ b/python/apps/taiga/src/taiga/workflows/repositories.py
@@ -5,7 +5,7 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
 from uuid import UUID
 
 from asgiref.sync import sync_to_async
@@ -262,3 +262,17 @@ def get_status(
         return qs.get()
     except WorkflowStatus.DoesNotExist:
         return None
+
+
+##########################################################
+# WorkflowStatus - update workflow status
+##########################################################
+
+
+@sync_to_async
+def update_workflow_status(status: WorkflowStatus, values: dict[str, Any] = {}) -> WorkflowStatus:
+    for attr, value in values.items():
+        setattr(status, attr, value)
+
+    status.save()
+    return status

--- a/python/apps/taiga/src/taiga/workflows/serializers/services.py
+++ b/python/apps/taiga/src/taiga/workflows/serializers/services.py
@@ -7,7 +7,7 @@
 
 
 from taiga.workflows.models import Workflow, WorkflowStatus
-from taiga.workflows.serializers import WorkflowSerializer, WorkflowStatusSerializer
+from taiga.workflows.serializers import WorkflowSerializer
 
 
 def serialize_workflow(workflow: Workflow, workflow_statuses: list[WorkflowStatus] = []) -> WorkflowSerializer:
@@ -17,15 +17,4 @@ def serialize_workflow(workflow: Workflow, workflow_statuses: list[WorkflowStatu
         slug=workflow.slug,
         order=workflow.order,
         statuses=workflow_statuses,
-    )
-
-
-def serialize_workflow_status(workflow_status: WorkflowStatus, workflow: Workflow) -> WorkflowStatusSerializer:
-    return WorkflowStatusSerializer(
-        id=workflow_status.id,
-        name=workflow_status.name,
-        slug=workflow_status.slug,
-        color=workflow_status.color,
-        order=workflow_status.order,
-        workflow=workflow,
     )

--- a/python/apps/taiga/src/taiga/workflows/services/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/services/__init__.py
@@ -7,14 +7,15 @@
 
 
 from decimal import Decimal
-from typing import cast
+from typing import Any, cast
 from uuid import UUID
 
 from taiga.workflows import events as workflow_events
 from taiga.workflows import repositories as workflows_repositories
 from taiga.workflows.models import Workflow, WorkflowStatus
-from taiga.workflows.serializers import WorkflowSerializer, WorkflowStatusSerializer
+from taiga.workflows.serializers import WorkflowSerializer
 from taiga.workflows.serializers import services as serializers_services
+from taiga.workflows.services import exceptions as ex
 
 DEFAULT_ORDER_OFFSET = Decimal(100)  # default offset when adding a workflow status
 
@@ -76,7 +77,7 @@ async def get_workflow_detail(project_id: UUID, workflow_slug: str) -> WorkflowS
 ##########################################################
 
 
-async def create_workflow_status(name: str, color: int, workflow: Workflow) -> WorkflowStatusSerializer:
+async def create_workflow_status(name: str, color: int, workflow: Workflow) -> WorkflowStatus:
     latest_status = await workflows_repositories.list_workflow_statuses(
         filters={"workflow_id": workflow.id}, order_by=["-order"], offset=0, limit=1
     )
@@ -87,16 +88,12 @@ async def create_workflow_status(name: str, color: int, workflow: Workflow) -> W
         name=name, slug=None, color=color, order=order, workflow=workflow
     )
 
-    serialized_workflow_status = serializers_services.serialize_workflow_status(
-        workflow=workflow, workflow_status=workflow_status
-    )
-
     # Emit event
     await workflow_events.emit_event_when_workflow_status_is_created(
-        project=workflow.project, workflow_status=serialized_workflow_status
+        project=workflow.project, workflow_status=workflow_status
     )
 
-    return serialized_workflow_status
+    return workflow_status
 
 
 ##########################################################
@@ -112,3 +109,20 @@ async def get_status(workflow_id: UUID, status_slug: str) -> WorkflowStatus | No
         },
         select_related=["workflow"],
     )
+
+
+##########################################################
+# update workflow status
+##########################################################
+
+
+async def update_workflow_status(status: WorkflowStatus, values: dict[str, Any] = {}) -> WorkflowStatus:
+    # TODO: Emit events
+
+    if not values:
+        return status
+
+    if "name" in values and values["name"] is None:
+        raise ex.TaigaValidationError("Name cannot be null")
+
+    return await workflows_repositories.update_workflow_status(status=status, values=values)

--- a/python/apps/taiga/src/taiga/workflows/services/exceptions.py
+++ b/python/apps/taiga/src/taiga/workflows/services/exceptions.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+
+from taiga.base.services.exceptions import TaigaServiceException
+
+
+class TaigaValidationError(TaigaServiceException):
+    ...

--- a/python/apps/taiga/tests/integration/taiga/workflows/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/workflows/test_repositories.py
@@ -140,6 +140,24 @@ async def test_get_project_without_workflow_statuses_ok() -> None:
 
 
 ##########################################################
+# WorkflowStatus - update workflow status
+##########################################################
+
+
+async def test_update_workflow_status_ok() -> None:
+    project = await f.create_project()
+    workflows = await _list_workflows(project=project)
+    workflow = workflows[0]
+    statuses = await _list_workflow_statuses(workflow=workflow)
+    status = statuses[0]
+    new_status_name = "new status name"
+    new_values = {"name": new_status_name}
+
+    updated_status = await repositories.update_workflow_status(status=status, values=new_values)
+    assert updated_status.name == new_status_name
+
+
+##########################################################
 # utils
 ##########################################################
 

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "f0ed1d46-b7b7-4317-bab5-3f373c85ed39",
+		"_postman_id": "1462f3c2-047e-41d0-9818-c34db07c7441",
 		"name": "taiga-next",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15018493"
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -2335,6 +2335,66 @@
 								"workflows",
 								"{{wf-slug}}",
 								"statuses"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "update workflow status",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"       pm.environment.set(\"ref1\", pm.response.json().ref);",
+									"       pm.environment.set(\"story_ref\", pm.response.json().ref);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"updated name\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/{{wf-slug}}/statuses/{{ws-slug}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"{{wf-slug}}",
+								"statuses",
+								"{{ws-slug}}"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "763d91af-2ab5-4eef-b0a7-fae0ce8b2e6c",
+		"_postman_id": "e0100565-fff3-4294-91a0-acf5e156e983",
 		"name": "taiga-next e2e",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15018493"
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -3033,6 +3033,11 @@
 							"listen": "test",
 							"script": {
 								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"    pm.environment.set(\"ws-slug\", pm.response.json().name);",
+									"});",
+									"",
 									"// Tests",
 									"pm.test(\"HTTP status code is correct\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -3093,6 +3098,82 @@
 								"workflows",
 								"{{wf-slug}}",
 								"statuses"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200.projects.{p}.workflows.{wf}.statuses.{ws}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    // Validate response API contract",
+									"    pm.expect(Object.keys(jsonRes).length).to.equal(6);",
+									"    pm.expect(jsonRes).to.have.property(\"id\");",
+									"    pm.expect(jsonRes).to.have.property(\"name\");",
+									"    pm.expect(jsonRes).to.have.property(\"slug\");",
+									"    pm.expect(jsonRes).to.have.property(\"color\");",
+									"    pm.expect(jsonRes).to.have.property(\"order\");",
+									"    pm.expect(jsonRes).to.have.property(\"workflow\");",
+									"    ",
+									"    pm.expect(Object.keys(jsonRes.workflow).length).to.equal(2);    ",
+									"    pm.expect(jsonRes.workflow).to.have.property(\"name\");",
+									"    pm.expect(jsonRes.workflow).to.have.property(\"slug\");",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"updated name\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/{{wf-slug}}/statuses/{{ws-slug}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"{{wf-slug}}",
+								"statuses",
+								"{{ws-slug}}"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_environment.json
+++ b/python/docs/postman/taiga.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "10f809b0-1dfc-4ddc-82ad-cf3fb85ae9fc",
+	"id": "913eae56-88c5-4745-a41e-1a3b56b9f8a3",
 	"name": "Taiga Next",
 	"values": [
 		{
@@ -127,6 +127,11 @@
 			"enabled": true
 		},
 		{
+			"key": "ws-slug",
+			"value": "new",
+			"enabled": true
+		},
+		{
 			"key": "ref1",
 			"value": "",
 			"type": "any",
@@ -164,6 +169,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-04-26T08:49:17.316Z",
-	"_postman_exported_using": "Postman/10.13.0"
+	"_postman_exported_at": "2023-07-03T10:03:33.055Z",
+	"_postman_exported_using": "Postman/10.15.4"
 }

--- a/python/docs/workflows/requirements.workflow.md
+++ b/python/docs/workflows/requirements.workflow.md
@@ -2,7 +2,7 @@
 
 ## Different requirements
 
-There are several "requierements" directories with different files:
+There are several "requirements" directories with different files:
 - `python/requirements` with requirements for linters and other dev dependencies which affect all the Python code
 - `python/apps/taiga/requirements` with requirements for Taiga application
 
@@ -20,8 +20,11 @@ When adding a new dependency, be aware of the different locations to place it, a
 
 2. Regenerate `requirements/devel.txt` and/or `requirements/prod.txt` files with
 ```bash
-pip-compile requirements/devel.in
-pip-compile requirements/prod.in
+pip install --upgrade pip-tools
+```
+```bash
+python -m piptools compile requirements/devel.in --resolver=backtracking  --upgrade
+python -m piptools compile requirements/prod.in --resolver=backtracking  --upgrade
 ```
 
 3. Check changes with git diff


### PR DESCRIPTION
This PR creates the endpoint that allows to update the workflow status's name.
> **PATCH** /projects/{{pj-id}}/workflows/{{wf-slug}}/statuses/{{ws-slug}}

![gif](https://media.giphy.com/media/8o0c4w1eIaFN2wzjgT/giphy.gif)

**NOTE**: The events involved within this endpoint will come in another PR soon

### What to test
- [x] Review the code
- [x] Tests are green

Create a new workflow status, and validate that:
- [ ] sending the correct params, its name is updated
- [ ] the response returns a 200 status, rendering the updated workflow
- [ ] sending an incorrect slug for either workflow or status, ir returns a 404 error
- [ ] sending a blank name rise a 422
- [ ] sending no params in the PATCH returns a 200 response without hitting the database