### PR TITLE
feat(comments): u#3411 delete comment API endpoint

### DIFF
--- a/python/apps/taiga/src/taiga/base/db/models/__init__.py
+++ b/python/apps/taiga/src/taiga/base/db/models/__init__.py
@@ -7,6 +7,8 @@
 
 import uuid
 
+from asgiref.sync import sync_to_async
+
 # isort: off
 from django.db.models import *  # noqa
 
@@ -36,3 +38,8 @@ class BaseModel(Model):
 
     class Meta:
         abstract = True
+
+
+@sync_to_async
+def get_contenttype_for_model(model: Model) -> ContentType:
+    return ContentType.objects.get_for_model(model)

--- a/python/apps/taiga/src/taiga/comments/events.py
+++ b/python/apps/taiga/src/taiga/comments/events.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from typing import Awaitable, Protocol
+
+from taiga.comments.models import Comment
+from taiga.projects.projects.models import Project
+from taiga.users.models import User
+
+
+class EventOnCreateCallable(Protocol):
+    def __call__(self, project: Project, comment: Comment) -> Awaitable[None]:
+        ...
+
+
+class EventOnDeleteCallable(Protocol):
+    def __call__(self, project: Project, comment: Comment, deleted_by: User) -> Awaitable[None]:
+        ...

--- a/python/apps/taiga/src/taiga/comments/models.py
+++ b/python/apps/taiga/src/taiga/comments/models.py
@@ -11,6 +11,7 @@ import functools
 from taiga.base.db import models
 from taiga.base.db.mixins import CreatedMetaInfoMixin, ModifiedAtMetaInfoMixin
 from taiga.base.utils.uuid import encode_uuid_to_b64str
+from taiga.projects.projects.models import Project
 
 
 class Comment(
@@ -52,3 +53,7 @@ class Comment(
     @functools.cached_property
     def b64id(self) -> str:
         return encode_uuid_to_b64str(self.id)
+
+    @property
+    def project(self) -> Project:
+        return getattr(self.content_object, "project")

--- a/python/apps/taiga/src/taiga/permissions/__init__.py
+++ b/python/apps/taiga/src/taiga/permissions/__init__.py
@@ -13,6 +13,11 @@ if TYPE_CHECKING:
     from taiga.users.models import AnyUser
 
 
+############################################################
+# Generic permissions
+############################################################
+
+
 class AllowAny(PermissionComponent):
     async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
         return True
@@ -23,14 +28,14 @@ class DenyAll(PermissionComponent):
         return False
 
 
-class IsAuthenticated(PermissionComponent):
-    async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
-        return bool(user and user.is_authenticated)
-
-
 class IsSuperUser(PermissionComponent):
     async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
         return bool(user and user.is_authenticated and user.is_superuser)
+
+
+class IsAuthenticated(PermissionComponent):
+    async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
+        return bool(user and user.is_authenticated)
 
 
 class HasPerm(PermissionComponent):
@@ -42,6 +47,22 @@ class HasPerm(PermissionComponent):
         from taiga.permissions import services as permissions_services
 
         return await permissions_services.user_has_perm(user=user, perm=self.object_perm, obj=obj)
+
+
+class IsRelatedToTheUser(PermissionComponent):
+    def __init__(self, field: str, *components: "PermissionComponent") -> None:
+        self.related_field = field
+        super().__init__(*components)
+
+    async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
+        from taiga.permissions import services as permissions_services
+
+        return await permissions_services.is_an_object_related_to_the_user(user=user, obj=obj, field=self.related_field)
+
+
+############################################################
+# Project permissions
+############################################################
 
 
 class CanViewProject(PermissionComponent):
@@ -58,15 +79,13 @@ class IsProjectAdmin(PermissionComponent):
         return await permissions_services.is_project_admin(user=user, obj=obj)
 
 
+############################################################
+# Workspace permissions
+############################################################
+
+
 class IsWorkspaceMember(PermissionComponent):
     async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
         from taiga.permissions import services as permissions_services
 
         return await permissions_services.is_workspace_member(user=user, obj=obj)
-
-
-class IsASelfRequest(PermissionComponent):
-    async def is_authorized(self, user: "AnyUser", obj: Any = None) -> bool:
-        from taiga.permissions import services as permissions_services
-
-        return await permissions_services.is_a_self_request(user=user, obj=obj)

--- a/python/apps/taiga/src/taiga/permissions/services.py
+++ b/python/apps/taiga/src/taiga/permissions/services.py
@@ -14,7 +14,7 @@ from taiga.projects.invitations import services as pj_invitations_services
 from taiga.projects.memberships import repositories as pj_memberships_repositories
 from taiga.projects.projects.models import Project
 from taiga.projects.roles import repositories as pj_roles_repositories
-from taiga.users.models import AnyUser, User
+from taiga.users.models import AnyUser
 from taiga.workspaces.memberships import repositories as workspace_memberships_repositories
 from taiga.workspaces.workspaces.models import Workspace
 
@@ -185,13 +185,8 @@ async def is_view_story_permission_deleted(old_permissions: list[str], new_permi
     return False
 
 
-async def is_a_self_request(user: AnyUser, obj: Any) -> bool:
+async def is_an_object_related_to_the_user(user: AnyUser, obj: Any, field: str = "user") -> bool:
     if user.is_anonymous:
         return False
 
-    if isinstance(obj, User):
-        return obj == user
-    elif obj and hasattr(obj, "user"):
-        return obj.user == user
-
-    return False
+    return obj and getattr(obj, field) == user

--- a/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
@@ -15,7 +15,7 @@ from taiga.base.api.permissions import check_permissions
 from taiga.base.validators import B64UUID
 from taiga.exceptions import api as ex
 from taiga.exceptions.api.errors import ERROR_400, ERROR_403, ERROR_404, ERROR_422
-from taiga.permissions import CanViewProject, IsASelfRequest, IsProjectAdmin
+from taiga.permissions import CanViewProject, IsProjectAdmin, IsRelatedToTheUser
 from taiga.projects.memberships import services as memberships_services
 from taiga.projects.memberships.api.validators import ProjectMembershipValidator
 from taiga.projects.memberships.models import ProjectMembership
@@ -26,7 +26,7 @@ from taiga.routers import routes
 # PERMISSIONS
 LIST_PROJECT_MEMBERSHIPS = CanViewProject()
 UPDATE_PROJECT_MEMBERSHIP = IsProjectAdmin()
-DELETE_PROJECT_MEMBERSHIP = IsProjectAdmin() | IsASelfRequest()
+DELETE_PROJECT_MEMBERSHIP = IsProjectAdmin() | IsRelatedToTheUser("user")
 
 
 ##########################################################

--- a/python/apps/taiga/src/taiga/stories/comments/api.py
+++ b/python/apps/taiga/src/taiga/stories/comments/api.py
@@ -7,7 +7,7 @@
 
 from uuid import UUID
 
-from fastapi import Depends, Response, status
+from fastapi import Depends, Query, Response, status
 from taiga.base.api import AuthRequest
 from taiga.base.api import pagination as api_pagination
 from taiga.base.api.pagination import PaginationQuery
@@ -28,7 +28,7 @@ from taiga.stories.stories.models import Story
 # PERMISSIONS
 CREATE_STORY_COMMENT = HasPerm("comment_story")
 LIST_STORY_COMMENTS = HasPerm("view_story")
-DELETE_STORY_COMMENTS = IsProjectAdmin() | IsRelatedToTheUser("created_by")
+DELETE_STORY_COMMENT = IsProjectAdmin() | IsRelatedToTheUser("created_by")
 
 
 ##########################################################
@@ -46,8 +46,8 @@ DELETE_STORY_COMMENTS = IsProjectAdmin() | IsRelatedToTheUser("created_by")
 async def create_story_comments(
     request: AuthRequest,
     form: CreateCommentValidator,
-    project_id: B64UUID,
-    ref: int,
+    project_id: B64UUID = Query(None, description="the project id (B64UUID)"),
+    ref: int = Query(None, description="the unique story reference within a project (int)"),
 ) -> Comment:
     """
     Add a comment to an story
@@ -78,8 +78,8 @@ async def create_story_comments(
 async def list_story_comments(
     request: AuthRequest,
     response: Response,
-    project_id: B64UUID,
-    ref: int,
+    project_id: B64UUID = Query(None, description="the project id (B64UUID)"),
+    ref: int = Query(None, description="the unique story reference within a project (str)"),
     pagination_params: PaginationQuery = Depends(),
     order_params: CommentOrderQuery = Depends(),  # type: ignore
 ) -> list[Comment]:
@@ -128,7 +128,7 @@ async def delete_story_comment(
     """
     story = await get_story_or_404(project_id=project_id, ref=ref)
     comment = await get_story_comment_or_404(comment_id=comment_id, story=story)
-    await check_permissions(permissions=DELETE_STORY_COMMENTS, user=request.user, obj=comment)
+    await check_permissions(permissions=DELETE_STORY_COMMENT, user=request.user, obj=comment)
 
     await comments_services.delete_comment(
         comment=comment,

--- a/python/apps/taiga/src/taiga/stories/comments/events/content.py
+++ b/python/apps/taiga/src/taiga/stories/comments/events/content.py
@@ -5,10 +5,17 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
-from taiga.base.serializers import BaseModel
+from taiga.base.serializers import UUIDB64, BaseModel
 from taiga.comments.serializers import CommentSerializer
+from taiga.users.serializers.nested import UserNestedSerializer
 
 
 class CreateStoryCommentContent(BaseModel):
     ref: int
     comment: CommentSerializer
+
+
+class DeleteStoryCommentContent(BaseModel):
+    id: UUIDB64
+    ref: int
+    deleted_by: UserNestedSerializer

--- a/python/apps/taiga/tests/integration/taiga/comments/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/comments/test_repositories.py
@@ -52,6 +52,43 @@ async def test_list_comments_by_content_object():
 
 
 ##########################################################
+# get_comment
+##########################################################
+
+
+async def tests_get_comment():
+    story1 = await f.create_story()
+    story2 = await f.create_story()
+    comment11 = await f.create_comment(content_object=story1)
+    comment21 = await f.create_comment(content_object=story2)
+    comment22 = await f.create_comment(content_object=story2)
+
+    assert await repositories.get_comment(filters={"id": comment22.id}) == comment22
+    assert await repositories.get_comment(filters={"content_object": story1}) == comment11
+    assert await repositories.get_comment(filters={"content_object": story1, "id": comment21.id}) is None
+    assert await repositories.get_comment(filters={"content_object": story1, "id": comment11.id}) == comment11
+
+
+##########################################################
+# update_comment
+##########################################################
+
+##########################################################
+# delete_comments
+##########################################################
+
+
+async def tests_delete_comments():
+    story1 = await f.create_story()
+    story2 = await f.create_story()
+    await f.create_comment(content_object=story2)
+    await f.create_comment(content_object=story2)
+
+    assert await repositories.delete_comments(filters={"content_object": story1}) == 0
+    assert await repositories.delete_comments(filters={"content_object": story2}) == 2
+
+
+##########################################################
 # misc - get_total_story_comments
 ##########################################################
 

--- a/python/apps/taiga/tests/unit/taiga/base/api/test_permissions.py
+++ b/python/apps/taiga/tests/unit/taiga/base/api/test_permissions.py
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.django_db
 
 # TODO: REFACTOR:
 #   - This tests should be unit tests (they shouldn't use the database).
-#   - There are tesst for classes from another module (taiga.permissions) that need to be moved.
+#   - There are tests for classes from another module (taiga.permissions) that need to be moved.
 
 #####################################################
 # check_permissions (is_authorized)

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -737,3 +737,19 @@ Content for:
       "comment": {... "comment object" ...}
   }
   ```
+
+
+#### `stories.comments.delete`
+
+It happens when a comment associated to an story is deleted.
+
+Content for:
+- project channel:
+  ```
+
+  {
+      "id": "comment id (UUIDB64)"
+      "ref": "story ref (int)"
+      "deletedBy": {... basic user info ...}
+  }
+  ```

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "1462f3c2-047e-41d0-9818-c34db07c7441",
+		"_postman_id": "f14e95f2-f030-40b7-8bc7-21414bd21c3b",
 		"name": "taiga-next",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "3299216"
+		"_exporter_id": "15018493"
 	},
 	"item": [
 		{
@@ -2920,7 +2920,7 @@
 								"exec": [
 									"// Post-request execution tasks",
 									"pm.test(\"Environment variable settings\", function () {",
-									"   pm.environment.set(\"story_version\", pm.response.json().version);",
+									"   pm.environment.set(\"story_comment_id\", pm.response.json().id);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -3031,6 +3031,54 @@
 									"key": "offset",
 									"value": "0"
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete story comment",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () { });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/stories/{{story_ref}}/comments/{{story_comment_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"stories",
+								"{{story_ref}}",
+								"comments",
+								"{{story_comment_id}}"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "e0100565-fff3-4294-91a0-acf5e156e983",
+		"_postman_id": "44181412-1bd5-4e11-a164-298627f3b498",
 		"name": "taiga-next e2e",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "3299216"
+		"_exporter_id": "15018493"
 	},
 	"item": [
 		{
@@ -4219,6 +4219,9 @@
 									"    pm.expect(jsonRes.createdBy).to.have.property(\"color\");",
 									"    numOfReturnedFields = Object.keys(jsonRes.createdBy).length;",
 									"    pm.expect(numOfReturnedFields).to.equal(3);",
+									"",
+									"    // Save story comment id to environment variables",
+									"    pm.environment.set(\"story_comment_id\", jsonRes.id);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -4352,6 +4355,56 @@
 									"key": "offset",
 									"value": "0"
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "204.projects.{p}.stories.{ref}.comments.{id}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(204);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/stories/{{story_ref}}/comments/{{story_comment_id}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"stories",
+								"{{story_ref}}",
+								"comments",
+								"{{story_comment_id}}"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_environment.json
+++ b/python/docs/postman/taiga.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "913eae56-88c5-4745-a41e-1a3b56b9f8a3",
+	"id": "09cbddbc-4b55-48a9-b70b-e31830d63108",
 	"name": "Taiga Next",
 	"values": [
 		{
@@ -166,9 +166,14 @@
 			"value": "",
 			"type": "any",
 			"enabled": true
+		},
+		{
+			"key": "story_comment_id",
+			"value": " ",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-07-03T10:03:33.055Z",
-	"_postman_exported_using": "Postman/10.15.4"
+	"_postman_exported_at": "2023-07-05T14:34:15.106Z",
+	"_postman_exported_using": "Postman/10.14.9"
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/xsFjLwT7NPfH2/giphy-downsized.gif)

This PR add a new endpoint to delete a comment (with his event) and apply a minor refactor to the comment module and to a permission class.

## How to validate
- [x] Review the code
- [x] Roses are red and tests are green
- [x] Create a comment and delete it (with postman, for example). 
      Only project admins and the comment owner can delete it.