### PR TITLE
feat(status): delete a workflow status

### DIFF
--- a/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
@@ -34,7 +34,9 @@ async def create_story(
     project: Project, workflow: Workflow, status_slug: str, user: User, title: str, description: str | None
 ) -> StoryDetailSerializer:
     # Validate data
-    workflow_status = await workflows_repositories.get_status(filters={"slug": status_slug, "workflow_id": workflow.id})
+    workflow_status = await workflows_repositories.get_workflow_status(
+        filters={"slug": status_slug, "workflow_id": workflow.id}
+    )
     if not workflow_status:
         raise ex.InvalidStatusError("The provided status is not valid.")
 
@@ -169,7 +171,7 @@ async def _validate_and_process_values_to_update(story: Story, values: dict[str,
     output = values.copy()
 
     if status_slug := output.pop("status", None):
-        status = await workflows_repositories.get_status(
+        status = await workflows_repositories.get_workflow_status(
             filters={"workflow_id": story.workflow_id, "slug": status_slug}
         )
 
@@ -243,7 +245,7 @@ async def reorder_stories(
     reorder: dict[str, Any] | None = None,
 ) -> ReorderStoriesSerializer:
     # check target_status exists
-    target_status = await workflows_repositories.get_status(
+    target_status = await workflows_repositories.get_workflow_status(
         filters={"project_id": project.id, "workflow_slug": workflow.slug, "slug": target_status_slug}
     )
     if not target_status:

--- a/python/apps/taiga/src/taiga/workflows/api/validators.py
+++ b/python/apps/taiga/src/taiga/workflows/api/validators.py
@@ -53,3 +53,7 @@ class ReorderWorkflowStatusesValidator(BaseModel):
 
     def get_reorder_dict(self) -> dict[str, Any]:
         return self.dict()["reorder"]
+
+
+class DeleteWorkflowStatusQuery(BaseModel):
+    move_to: str | None

--- a/python/apps/taiga/src/taiga/workflows/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/events/__init__.py
@@ -9,6 +9,7 @@ from taiga.events import events_manager
 from taiga.projects.projects.models import Project
 from taiga.workflows.events.content import (
     CreateWorkflowStatusContent,
+    DeleteWorkflowStatusContent,
     ReorderWorkflowStatusesContent,
     UpdateWorkflowStatusContent,
 )
@@ -18,6 +19,7 @@ from taiga.workflows.serializers import ReorderWorkflowStatusesSerializer
 CREATE_WORKFLOW_STATUS = "workflowstatuses.create"
 UPDATE_WORKFLOW_STATUS = "workflowstatuses.update"
 REORDER_WORKFLOW_STATUS = "workflowstatuses.reorder"
+DELETE_WORKFLOW_STATUS = "workflowstatuses.delete"
 
 
 async def emit_event_when_workflow_status_is_created(project: Project, workflow_status: WorkflowStatus) -> None:
@@ -43,4 +45,17 @@ async def emit_event_when_workflow_statuses_are_reordered(
         project=project,
         type=REORDER_WORKFLOW_STATUS,
         content=ReorderWorkflowStatusesContent(reorder=reorder),
+    )
+
+
+async def emit_event_when_workflow_status_is_deleted(
+    project: Project, workflow_status: WorkflowStatus, move_to_status_slug: str | None
+) -> None:
+    await events_manager.publish_on_project_channel(
+        project=project,
+        type=DELETE_WORKFLOW_STATUS,
+        content=DeleteWorkflowStatusContent(
+            workflow_status=workflow_status,
+            move_to_slug=move_to_status_slug,
+        ),
     )

--- a/python/apps/taiga/src/taiga/workflows/events/content.py
+++ b/python/apps/taiga/src/taiga/workflows/events/content.py
@@ -19,3 +19,8 @@ class UpdateWorkflowStatusContent(BaseModel):
 
 class ReorderWorkflowStatusesContent(BaseModel):
     reorder: ReorderWorkflowStatusesSerializer
+
+
+class DeleteWorkflowStatusContent(BaseModel):
+    workflow_status: WorkflowStatusSerializer
+    move_to_slug: str | None

--- a/python/apps/taiga/src/taiga/workflows/models.py
+++ b/python/apps/taiga/src/taiga/workflows/models.py
@@ -10,6 +10,7 @@ from typing import Any
 from taiga.base.db import models
 from taiga.base.utils.datetime import timestamp_mics
 from taiga.base.utils.slug import generate_incremental_int_suffix, slugify_uniquely_for_queryset
+from taiga.projects.projects.models import Project
 
 
 class Workflow(models.BaseModel):
@@ -76,6 +77,10 @@ class WorkflowStatus(models.BaseModel):
 
     def __repr__(self) -> str:
         return f"<WorkflowStatus {self.name}>"
+
+    @property
+    def project(self) -> Project:
+        return self.workflow.project
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         if not self.slug:

--- a/python/apps/taiga/src/taiga/workflows/services/exceptions.py
+++ b/python/apps/taiga/src/taiga/workflows/services/exceptions.py
@@ -15,3 +15,12 @@ class TaigaValidationError(TaigaServiceException):
 
 class InvalidWorkflowStatusError(TaigaServiceException):
     ...
+
+
+class NonExistingMoveToStatus(TaigaServiceException):
+    ...
+
+
+class SameMoveToStatus(TaigaServiceException):
+    ...
+

--- a/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
@@ -32,7 +32,7 @@ async def test_create_story_ok():
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
         patch("taiga.stories.stories.services.stories_events", autospec=True) as fake_stories_events,
     ):
-        fake_workflows_repo.get_status.return_value = status
+        fake_workflows_repo.get_workflow_status.return_value = status
         fake_stories_repo.list_stories.return_value = None
         fake_stories_repo.create_story.return_value = story
         fake_stories_repo.get_story.return_value = story
@@ -57,7 +57,7 @@ async def test_create_story_ok():
             user_id=user.id,
             order=Decimal(100),
         )
-        fake_workflows_repo.get_status.assert_awaited_once_with(
+        fake_workflows_repo.get_workflow_status.assert_awaited_once_with(
             filters={"slug": status.slug, "workflow_id": status.workflow.id}
         )
         fake_stories_repo.list_stories.assert_awaited_once_with(
@@ -77,7 +77,7 @@ async def test_create_story_invalid_status():
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
     ):
 
-        fake_workflows_repo.get_status.return_value = None
+        fake_workflows_repo.get_workflow_status.return_value = None
         await services.create_story(
             project=story.project,
             workflow=build_workflow_serializer(story),
@@ -293,7 +293,7 @@ async def test_validate_and_process_values_to_update_ok_without_status():
     ):
         valid_values = await services._validate_and_process_values_to_update(story=story, values=values)
 
-        fake_workflows_repo.get_status.assert_not_awaited()
+        fake_workflows_repo.get_workflow_status.assert_not_awaited()
         fake_stories_repo.list_stories.assert_not_awaited()
 
         assert valid_values == values
@@ -308,12 +308,12 @@ async def test_validate_and_process_values_to_update_ok_with_status_empty():
         patch("taiga.stories.stories.services.stories_repositories", autospec=True) as fake_stories_repo,
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
     ):
-        fake_workflows_repo.get_status.return_value = status
+        fake_workflows_repo.get_workflow_status.return_value = status
         fake_stories_repo.list_stories.return_value = []
 
         valid_values = await services._validate_and_process_values_to_update(story=story, values=values)
 
-        fake_workflows_repo.get_status.assert_awaited_once_with(
+        fake_workflows_repo.get_workflow_status.assert_awaited_once_with(
             filters={"workflow_id": story.workflow_id, "slug": values["status"]},
         )
         fake_stories_repo.list_stories.assert_awaited_once_with(
@@ -338,12 +338,12 @@ async def test_validate_and_process_values_to_update_ok_with_status_not_empty():
         patch("taiga.stories.stories.services.stories_repositories", autospec=True) as fake_stories_repo,
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
     ):
-        fake_workflows_repo.get_status.return_value = status
+        fake_workflows_repo.get_workflow_status.return_value = status
         fake_stories_repo.list_stories.return_value = [story2]
 
         valid_values = await services._validate_and_process_values_to_update(story=story, values=values)
 
-        fake_workflows_repo.get_status.assert_awaited_once_with(
+        fake_workflows_repo.get_workflow_status.assert_awaited_once_with(
             filters={"workflow_id": story.workflow_id, "slug": values["status"]},
         )
         fake_stories_repo.list_stories.assert_awaited_once_with(
@@ -367,11 +367,11 @@ async def test_validate_and_process_values_to_update_ok_with_same_status():
         patch("taiga.stories.stories.services.stories_repositories", autospec=True) as fake_stories_repo,
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
     ):
-        fake_workflows_repo.get_status.return_value = status
+        fake_workflows_repo.get_workflow_status.return_value = status
 
         valid_values = await services._validate_and_process_values_to_update(story=story, values=values)
 
-        fake_workflows_repo.get_status.assert_awaited_once_with(
+        fake_workflows_repo.get_workflow_status.assert_awaited_once_with(
             filters={"workflow_id": story.workflow_id, "slug": values["status"]},
         )
         fake_stories_repo.list_stories.assert_not_awaited()
@@ -389,12 +389,12 @@ async def test_validate_and_process_values_to_update_error_wrong_status():
         patch("taiga.stories.stories.services.stories_repositories", autospec=True) as fake_stories_repo,
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
     ):
-        fake_workflows_repo.get_status.return_value = None
+        fake_workflows_repo.get_workflow_status.return_value = None
 
         with (pytest.raises(ex.InvalidStatusError)):
             await services._validate_and_process_values_to_update(story=story, values=values)
 
-        fake_workflows_repo.get_status.assert_awaited_once_with(
+        fake_workflows_repo.get_workflow_status.assert_awaited_once_with(
             filters={"workflow_id": story.workflow_id, "slug": "wrong_status"},
         )
         fake_stories_repo.list_stories.assert_not_awaited()
@@ -468,7 +468,7 @@ async def test_reorder_stories_ok():
         patch("taiga.stories.stories.services.stories_events", autospec=True) as fake_stories_events,
     ):
         target_status = f.build_workflow_status()
-        fake_workflows_repo.get_status.return_value = target_status
+        fake_workflows_repo.get_workflow_status.return_value = target_status
         reorder_story = f.build_story(ref=3)
         fake_stories_repo.get_story.return_value = reorder_story
         s1 = f.build_story(ref=13)
@@ -495,7 +495,7 @@ async def test_reorder_story_workflowstatus_does_not_exist():
         patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,
         pytest.raises(ex.InvalidStatusError),
     ):
-        fake_workflows_repo.get_status.return_value = None
+        fake_workflows_repo.get_workflow_status.return_value = None
 
         await services.reorder_stories(
             project=f.build_project(),
@@ -513,7 +513,7 @@ async def test_reorder_story_story_ref_does_not_exist():
         pytest.raises(ex.InvalidStoryRefError),
     ):
         target_status = f.build_workflow_status()
-        fake_workflows_repo.get_status.return_value = target_status
+        fake_workflows_repo.get_workflow_status.return_value = target_status
 
         fake_stories_repo.get_story.return_value = None
 
@@ -533,7 +533,7 @@ async def test_reorder_story_not_all_stories_exist():
         pytest.raises(ex.InvalidStoryRefError),
     ):
         target_status = f.build_workflow_status()
-        fake_workflows_repo.get_status.return_value = target_status
+        fake_workflows_repo.get_workflow_status.return_value = target_status
 
         reorder_story = f.build_story(ref=3)
         fake_stories_repo.get_story.return_value = reorder_story

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -657,6 +657,20 @@ Content for:
   }
   ```
 
+#### `workflowstatuses.delete`
+
+It happens when a workflow status has been deleted.
+
+Content for:
+- project channel:
+  ```
+  {
+      "workflowStatus": {... "workflow status object" ...},
+      "moveToSlug": null | "closed"
+  }
+  ```
+
+
 #### `stories.create`
 
 It happens when a new story has been created.

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "50db7858-ee96-4fb4-852e-b145af14d29d",
+		"_postman_id": "0a4818c9-b029-4c91-bdbe-b3ad629a9dcf",
 		"name": "taiga-next",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -2453,6 +2454,69 @@
 								"{{wf-slug}}",
 								"statuses",
 								"reorder"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "delete workflow status",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/{{wf-slug}}/statuses/{{ws-slug}}?moveTo=in-progress",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"{{wf-slug}}",
+								"statuses",
+								"{{ws-slug}}"
+							],
+							"query": [
+								{
+									"key": "moveTo",
+									"value": "in-progress"
+								}
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,8 +1,8 @@
 {
 	"info": {
-		"_postman_id": "2beccc64-63bc-4d50-ad5e-f7ad634cdd49",
 		"name": "taiga-next e2e",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "3299216"
 	},
 	"item": [
 		{
@@ -3252,6 +3252,74 @@
 								"main",
 								"statuses",
 								"reorder"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "204.projects.{p}.workflows.{wf}.statuses.{ws}",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(204);",
+									"",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "DELETE",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/{{wf-slug}}/statuses/{{ws-slug}}?moveTo=in-progress",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"{{wf-slug}}",
+								"statuses",
+								"{{ws-slug}}"
+							],
+							"query": [
+								{
+									"key": "moveTo",
+									"value": "in-progress"
+								}
 							]
 						}
 					},


### PR DESCRIPTION
This PR allows to delete a workspace status, giving the option to avoid deleting its stories by moving them to another valid workspace status (in the same workflow).

`DELETE /projects/TH4C5hvNEe61Tw3m0DW-EQ/workflows/main/statuses/Closed?moveTo=closed`

![giphy](https://media.giphy.com/media/qplE1UXdbkyYuv3DCo/giphy.gif)

### What to test

- [x] Review the code
- [ ] Tests are green

For the next validations use the api in conjunction with this other frontend's branch: `us/2035/task/3773/delete-status-modal`.

As a project admin, go to the kanban and create two stories for every workflow status in the kanban. 
- [x] Delete the status most in the right, clicking on "Move them to another status" and selecting any other status.
Verify the status is deleted, but their stories have been moved to the specified status (at the end of previous stories and in the same previous order). It gives a 204 (no content)
- [x] Keep deleting statuses and moving its stories to another status, until we just have the last status with all the previous stories.
- [x] Delete the last status contaning all the stories, and click on "Delete the stories too".
Verify that both the status and its stories are deleted from the database. The kanban should be empty.

Using the api, verify the error responses:

- [x] 403 forbidden for not-an-admin user
- [x] 404 using a wrong id in the URL
- [x] 400 when trying to move the stories to the same workflow status being deleted
- [x] 400 when trying to move the stories to a workflow status that doesn't exist

- [x] Hi five

Thanks!
