### PR TITLE
feat(workflow status): u#2033 emit event when workflow status is updated

### DIFF
--- a/python/apps/taiga/src/taiga/workflows/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/api/__init__.py
@@ -150,6 +150,7 @@ async def update_workflow_status(
     workflow_status = await get_workflow_status_or_404(workflow_id=workflow.id, workflow_status_slug=slug)
 
     return await workflows_services.update_workflow_status(
+        workflow=workflow,
         workflow_status=workflow_status,
         values=form.dict(exclude_unset=True),
     )

--- a/python/apps/taiga/src/taiga/workflows/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/events/__init__.py
@@ -7,10 +7,11 @@
 
 from taiga.events import events_manager
 from taiga.projects.projects.models import Project
-from taiga.workflows.events.content import CreateWorkflowStatusContent
+from taiga.workflows.events.content import CreateWorkflowStatusContent, UpdateWorkflowStatusContent
 from taiga.workflows.models import WorkflowStatus
 
 CREATE_WORKFLOW_STATUS = "workflowstatuses.create"
+UPDATE_WORKFLOW_STATUS = "workflowstatuses.update"
 
 
 async def emit_event_when_workflow_status_is_created(project: Project, workflow_status: WorkflowStatus) -> None:
@@ -18,4 +19,12 @@ async def emit_event_when_workflow_status_is_created(project: Project, workflow_
         project=project,
         type=CREATE_WORKFLOW_STATUS,
         content=CreateWorkflowStatusContent(workflow_status=workflow_status),
+    )
+
+
+async def emit_event_when_workflow_status_is_updated(project: Project, workflow_status: WorkflowStatus) -> None:
+    await events_manager.publish_on_project_channel(
+        project=project,
+        type=UPDATE_WORKFLOW_STATUS,
+        content=UpdateWorkflowStatusContent(workflow_status=workflow_status),
     )

--- a/python/apps/taiga/src/taiga/workflows/events/content.py
+++ b/python/apps/taiga/src/taiga/workflows/events/content.py
@@ -11,3 +11,7 @@ from taiga.workflows.serializers import WorkflowStatusSerializer
 
 class CreateWorkflowStatusContent(BaseModel):
     workflow_status: WorkflowStatusSerializer
+
+
+class UpdateWorkflowStatusContent(BaseModel):
+    workflow_status: WorkflowStatusSerializer


### PR DESCRIPTION
![](https://media.giphy.com/media/4XDztBSUmz2kJSmyaN/giphy-downsized.gif)
¡eventazo!

This PR adds an event when the workflow status is changed.

How to review:
- [x] check the code
- [x] tests are green
- [x] with Postman edit the name of a status and check the event is properly issued

mind! it also changes "workflow_events" for "workflows_events" following the naming convention.