### PR TITLE
fix(comments): u#3411 apply correct permissions to delete comment

### DIFF
--- a/python/apps/taiga/src/taiga/stories/comments/api.py
+++ b/python/apps/taiga/src/taiga/stories/comments/api.py
@@ -28,7 +28,7 @@ from taiga.stories.stories.models import Story
 # PERMISSIONS
 CREATE_STORY_COMMENT = HasPerm("comment_story")
 LIST_STORY_COMMENTS = HasPerm("view_story")
-DELETE_STORY_COMMENT = IsProjectAdmin() | IsRelatedToTheUser("created_by")
+DELETE_STORY_COMMENT = IsProjectAdmin() | (IsRelatedToTheUser("created_by") & HasPerm("comment_story"))
 
 
 ##########################################################


### PR DESCRIPTION
![](https://media.giphy.com/media/wkKRo7N0T1ONO/giphy.gif)

This PR fixes the application of permissions to delete a comment.

- [ ] check the code
- [ ] tests are green
- [ ] member1 creates a comment and deletes a comment - still OK
- [ ] member1 creates a comment; the pj-admin removes permission "can comment"; tries to delete the comment - PERMISSION FAIL