### PR TITLE
U/2034/endpoint reorder wf status

### DIFF
--- a/python/apps/taiga/src/taiga/stories/stories/repositories.py
+++ b/python/apps/taiga/src/taiga/stories/stories/repositories.py
@@ -233,12 +233,8 @@ def list_stories_to_reorder(filters: StoryFilters = {}) -> list[Story]:
     """
     qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
 
-    refs = filters["refs"]
-    result = [None] * len(refs)  # create an empty list the size of the references list
-    for story in qs:
-        result[refs.index(story.ref)] = story  # type: ignore[call-overload]
-
-    return result  # type: ignore[return-value]
+    stories = {s.ref: s for s in qs}
+    return [stories[ref] for ref in filters["refs"] if stories.get(ref) is not None]
 
 
 @sync_to_async

--- a/python/apps/taiga/src/taiga/workflows/events/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/events/__init__.py
@@ -7,11 +7,17 @@
 
 from taiga.events import events_manager
 from taiga.projects.projects.models import Project
-from taiga.workflows.events.content import CreateWorkflowStatusContent, UpdateWorkflowStatusContent
+from taiga.workflows.events.content import (
+    CreateWorkflowStatusContent,
+    ReorderWorkflowStatusesContent,
+    UpdateWorkflowStatusContent,
+)
 from taiga.workflows.models import WorkflowStatus
+from taiga.workflows.serializers import ReorderWorkflowStatusesSerializer
 
 CREATE_WORKFLOW_STATUS = "workflowstatuses.create"
 UPDATE_WORKFLOW_STATUS = "workflowstatuses.update"
+REORDER_WORKFLOW_STATUS = "workflowstatuses.reorder"
 
 
 async def emit_event_when_workflow_status_is_created(project: Project, workflow_status: WorkflowStatus) -> None:
@@ -27,4 +33,14 @@ async def emit_event_when_workflow_status_is_updated(project: Project, workflow_
         project=project,
         type=UPDATE_WORKFLOW_STATUS,
         content=UpdateWorkflowStatusContent(workflow_status=workflow_status),
+    )
+
+
+async def emit_event_when_workflow_statuses_are_reordered(
+    project: Project, reorder: ReorderWorkflowStatusesSerializer
+) -> None:
+    await events_manager.publish_on_project_channel(
+        project=project,
+        type=REORDER_WORKFLOW_STATUS,
+        content=ReorderWorkflowStatusesContent(reorder=reorder),
     )

--- a/python/apps/taiga/src/taiga/workflows/events/content.py
+++ b/python/apps/taiga/src/taiga/workflows/events/content.py
@@ -6,7 +6,7 @@
 # Copyright (c) 2023-present Kaleidos INC
 
 from taiga.base.serializers import BaseModel
-from taiga.workflows.serializers import WorkflowStatusSerializer
+from taiga.workflows.serializers import ReorderWorkflowStatusesSerializer, WorkflowStatusSerializer
 
 
 class CreateWorkflowStatusContent(BaseModel):
@@ -15,3 +15,7 @@ class CreateWorkflowStatusContent(BaseModel):
 
 class UpdateWorkflowStatusContent(BaseModel):
     workflow_status: WorkflowStatusSerializer
+
+
+class ReorderWorkflowStatusesContent(BaseModel):
+    reorder: ReorderWorkflowStatusesSerializer

--- a/python/apps/taiga/src/taiga/workflows/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/serializers/__init__.py
@@ -30,3 +30,20 @@ class WorkflowSerializer(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class ReorderSerializer(BaseModel):
+    place: str
+    status: str
+
+    class Config:
+        orm_mode = True
+
+
+class ReorderWorkflowStatusesSerializer(BaseModel):
+    workflow: WorkflowNestedSerializer
+    statuses: list[str]
+    reorder: ReorderSerializer
+
+    class Config:
+        orm_mode = True

--- a/python/apps/taiga/src/taiga/workflows/serializers/services.py
+++ b/python/apps/taiga/src/taiga/workflows/serializers/services.py
@@ -6,8 +6,10 @@
 # Copyright (c) 2023-present Kaleidos INC
 
 
+from typing import Any
+
 from taiga.workflows.models import Workflow, WorkflowStatus
-from taiga.workflows.serializers import WorkflowSerializer
+from taiga.workflows.serializers import ReorderWorkflowStatusesSerializer, WorkflowSerializer
 
 
 def serialize_workflow(workflow: Workflow, workflow_statuses: list[WorkflowStatus] = []) -> WorkflowSerializer:
@@ -18,3 +20,10 @@ def serialize_workflow(workflow: Workflow, workflow_statuses: list[WorkflowStatu
         order=workflow.order,
         statuses=workflow_statuses,
     )
+
+
+def serialize_reorder_workflow_statuses(
+    workflow: Workflow, statuses: list[str], reorder: dict[str, Any] | None = None
+) -> ReorderWorkflowStatusesSerializer:
+
+    return ReorderWorkflowStatusesSerializer(workflow=workflow, statuses=statuses, reorder=reorder)

--- a/python/apps/taiga/src/taiga/workflows/services/exceptions.py
+++ b/python/apps/taiga/src/taiga/workflows/services/exceptions.py
@@ -11,3 +11,7 @@ from taiga.base.services.exceptions import TaigaServiceException
 
 class TaigaValidationError(TaigaServiceException):
     ...
+
+
+class InvalidWorkflowStatusError(TaigaServiceException):
+    ...

--- a/python/apps/taiga/tests/integration/taiga/stories/stories/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/stories/test_repositories.py
@@ -245,3 +245,18 @@ async def test_list_stories_to_reorder() -> None:
     assert stories[0].ref == story3.ref
     assert stories[1].ref == story1.ref
     assert stories[2].ref == story2.ref
+
+
+async def test_list_stories_to_reorder_bad_names() -> None:
+    project = await f.create_project()
+    workflow = await sync_to_async(project.workflows.first)()
+    status = await sync_to_async(workflow.statuses.first)()
+    story1 = await f.create_story(project=project, workflow=workflow, status=status)
+    story2 = await f.create_story(project=project, workflow=workflow, status=status)
+    non_existing_reference = 9999999
+
+    refs = [story1.ref, non_existing_reference, story2.ref]
+    stories = await repositories.list_stories_to_reorder(filters={"status_id": status.id, "refs": refs})
+    assert len(stories) == 2
+    assert stories[0].ref == story1.ref
+    assert stories[1].ref == story2.ref

--- a/python/apps/taiga/tests/unit/taiga/workflows/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/workflows/test_services.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from taiga.base.repositories.neighbors import Neighbor
 from taiga.workflows import services
 from taiga.workflows.services import exceptions as ex
 from tests.utils import factories as f
@@ -148,3 +149,114 @@ async def test_update_workflow_status_none_name():
         await services.update_workflow_status(workflow=status.workflow, workflow_status=status, values=values)
         fake_workflows_repo.update_workflow_status.assert_not_awaited()
         fake_workflows_events.emit_event_when_workflow_status_is_updated.assert_not_awaited()
+
+
+#######################################################
+# _calculate_offset
+#######################################################
+
+
+async def test_calculate_offset() -> None:
+    workflow = f.build_workflow()
+
+    with (patch("taiga.workflows.services.workflows_repositories", autospec=True) as fake_workflows_repo,):
+        prev_st = f.build_workflow_status(workflow=workflow, order=150)
+        reord_st = f.build_workflow_status(workflow=workflow, order=250)
+        next_st = f.build_workflow_status(workflow=workflow, order=300)
+
+        # after
+        fake_workflows_repo.list_workflow_status_neighbors.return_value = Neighbor(prev=None, next=next_st)
+        offset, pre_order = await services._calculate_offset(
+            total_statuses_to_reorder=1, workflow=workflow, reorder_status=reord_st, reorder_place="after"
+        )
+        assert pre_order == reord_st.order
+        assert offset == Decimal(25)
+
+        fake_workflows_repo.list_workflow_status_neighbors.return_value = Neighbor(next=None, prev=None)
+        offset, pre_order = await services._calculate_offset(
+            total_statuses_to_reorder=1, workflow=workflow, reorder_status=reord_st, reorder_place="after"
+        )
+        assert pre_order == reord_st.order
+        assert offset == Decimal(100)
+
+        # before
+        fake_workflows_repo.list_workflow_status_neighbors.return_value = Neighbor(next=None, prev=prev_st)
+        offset, pre_order = await services._calculate_offset(
+            total_statuses_to_reorder=1, workflow=workflow, reorder_status=reord_st, reorder_place="before"
+        )
+        assert pre_order == prev_st.order
+        assert offset == Decimal(50)
+
+        fake_workflows_repo.list_workflow_status_neighbors.return_value = Neighbor(next=None, prev=None)
+        offset, pre_order = await services._calculate_offset(
+            total_statuses_to_reorder=1, workflow=workflow, reorder_status=reord_st, reorder_place="before"
+        )
+        assert pre_order == Decimal(0)
+        assert offset == Decimal(125)
+
+
+#######################################################
+# update reorder_statuses
+#######################################################
+
+
+async def test_reorder_workflow_statuses_ok():
+    with (
+        patch("taiga.workflows.services.workflows_repositories", autospec=True) as fake_workflows_repo,
+        patch("taiga.workflows.services.workflows_events", autospec=True) as fake_workflows_events,
+    ):
+        workflow = f.build_workflow()
+        status1 = f.build_workflow_status(workflow=workflow, order=1)
+        status2 = f.build_workflow_status(workflow=workflow, order=2)
+        status3 = f.build_workflow_status(workflow=workflow, order=3)
+        fake_workflows_repo.get_status.return_value = status1
+        fake_workflows_repo.list_workflow_statuses_to_reorder.return_value = [status3, status2]
+
+        await services.reorder_workflow_statuses(
+            workflow=f.build_workflow(),
+            statuses=[status3.slug, status2.slug],
+            reorder={"place": "after", "status": status1.slug},
+        )
+
+        fake_workflows_repo.bulk_update_workflow_statuses.assert_awaited_once_with(
+            objs_to_update=[status3, status2], fields_to_update=["order"]
+        )
+        fake_workflows_events.emit_event_when_workflow_statuses_are_reordered.assert_awaited_once()
+
+
+async def test_reorder_workflow_status_repeated():
+    with (pytest.raises(ex.InvalidWorkflowStatusError),):
+
+        await services.reorder_workflow_statuses(
+            workflow=f.build_workflow(),
+            statuses=["new"],
+            reorder={"place": "after", "status": "new"},
+        )
+
+
+async def test_reorder_anchor_workflow_status_does_not_exist():
+    with (
+        patch("taiga.workflows.services.workflows_repositories", autospec=True) as fake_workflows_repo,
+        pytest.raises(ex.InvalidWorkflowStatusError),
+    ):
+        fake_workflows_repo.get_status.return_value = None
+
+        await services.reorder_workflow_statuses(
+            workflow=f.build_workflow(),
+            statuses=["in-progress"],
+            reorder={"place": "after", "status": "mooo"},
+        )
+
+
+async def test_reorder_any_workflow_status_does_not_exist():
+    with (
+        patch("taiga.workflows.services.workflows_repositories", autospec=True) as fake_workflows_repo,
+        pytest.raises(ex.InvalidWorkflowStatusError),
+    ):
+        fake_workflows_repo.get_status.return_value = None
+
+        await services.reorder_workflow_statuses(
+            workflow=f.build_workflow(),
+            statuses=["in-progress", "mooo"],
+            reorder={"place": "after", "status": "new"},
+        )

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -616,10 +616,46 @@ Content for:
 - project channel:
   ```
   {
-      "status": {... "workflow status object" ...}
+      "workflowStatus": {... "workflow status object" ...}
   }
   ```
 
+
+#### `workflowstatuses.update`
+
+It happens when a workflow status has been updated.
+
+Content for:
+- project channel:
+  ```
+  {
+      "workflowStatus": {... "workflow status object" ...}
+  }
+  ```
+
+
+#### `workflowstatuses.reorder`
+
+It happens when some workflow statuses are reordered.
+
+Content for:
+- project channel:
+  ```
+  {
+      "reorder": {
+          "workflow": {... workflow object ...},
+	      "statuses": [
+		      "moved wf_status slug (str)",
+		      "moved wf_status slug (str)",
+              ....
+	      ],
+	      "reorder": {
+		      "place": "'before' or 'after'",
+		      "status": "worklflow status slug (str)"
+	      }
+      }
+  }
+  ```
 
 #### `stories.create`
 

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "f14e95f2-f030-40b7-8bc7-21414bd21c3b",
+		"_postman_id": "50db7858-ee96-4fb4-852e-b145af14d29d",
 		"name": "taiga-next",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15018493"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -2395,6 +2394,65 @@
 								"{{wf-slug}}",
 								"statuses",
 								"{{ws-slug}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "reorder workflows statuses",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"   // pm.environment.set(\"pj-id\", pm.response.json().slug);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"statuses\": [\"ready\"],\n    \"reorder\": {\n        \"place\": \"after\",\n        \"status\": \"in-progress\"\n    }\n\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/{{wf-slug}}/statuses/reorder",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"{{wf-slug}}",
+								"statuses",
+								"reorder"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "44181412-1bd5-4e11-a164-298627f3b498",
+		"_postman_id": "2beccc64-63bc-4d50-ad5e-f7ad634cdd49",
 		"name": "taiga-next e2e",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15018493"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -3174,6 +3173,85 @@
 								"{{wf-slug}}",
 								"statuses",
 								"{{ws-slug}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200.projects.{p}.workflows.{wf}.statuses.reorder",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    // Validate response API contract",
+									"    pm.expect(jsonRes).to.have.property(\"workflow\");",
+									"    pm.expect(jsonRes).to.have.property(\"statuses\");",
+									"    pm.expect(jsonRes).to.have.property(\"reorder\");",
+									"    // Validate we're not returning more fields than expected",
+									"    var numOfReturnedFields = Object.keys(jsonRes).length;",
+									"    pm.expect(numOfReturnedFields).to.equal(3);    ",
+									"",
+									"    pm.expect(jsonRes.workflow).to.have.property(\"slug\");",
+									"    pm.expect(jsonRes.workflow).to.have.property(\"name\");",
+									"",
+									"    pm.expect(jsonRes.reorder).to.have.property(\"place\");",
+									"    pm.expect(jsonRes.reorder).to.have.property(\"status\");",
+									"});",
+									"",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"statuses\": [\"new\", \"in-progress\"],\n    \"reorder\": {\n        \"place\": \"before\",\n        \"status\": \"done\"\n    }   \n\n}\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/projects/{{pj-id}}/workflows/main/statuses/reorder",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"projects",
+								"{{pj-id}}",
+								"workflows",
+								"main",
+								"statuses",
+								"reorder"
 							]
 						}
 					},


### PR DESCRIPTION
![](https://media.giphy.com/media/tJMVcTfzDdL1pOGxlk/giphy.gif)

ORRRRDERRRRR

This PR adds "reorder worklows statuses functionality". It's similar to reorder stories and it's able to reorder more than one workflow status. Additionally I've found a bug in reorder stories and fixed it (different commit).
Found missing events documentation and added it.

How to test:
- [x] check the code
- [x] tests are green
- [x] run front (main) and back (branch) and open Postman
- [x] new project with the given order for statuses: new, ready, in-progress, done. create some stories in different statuses.
- [x] check swagger to learn the request
- [x] in postman, try to reorder one or more statuses
- [x] f5 in the project - new order is ok
- [x] open the last story of the kanban - check the "next" story arrow is disabled
- [x] in postman, move one status after the last one
- [x] f5 in the story - now it has a next-story in the link
- [x] check the events are properly sent
- [x] events documentation!