### PR TITLE
fix(invitations): i#3674 emit event when pj/ws invitations are updated

### DIFF
--- a/python/apps/taiga/src/taiga/projects/invitations/services/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/invitations/services/__init__.py
@@ -154,9 +154,10 @@ async def create_project_invitations(
     for invitation in invitations_to_send_list:
         await send_project_invitation_email(invitation=invitation)
 
-    if invitations_to_send_list:
+    if len(invitations_to_create) + len(invitations_to_update) > 0:
+        invitations_to_publish = (invitations_to_create | invitations_to_update).values()
         await invitations_events.emit_event_when_project_invitations_are_created(
-            project=project, invitations=invitations_to_send_list
+            project=project, invitations=invitations_to_publish
         )
 
     return serializers_services.serialize_create_project_invitations(

--- a/python/apps/taiga/src/taiga/workspaces/invitations/services/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/services/__init__.py
@@ -140,9 +140,10 @@ async def create_workspace_invitations(
     for invitation in invitations_to_send_list:
         await send_workspace_invitation_email(invitation=invitation)
 
-    if invitations_to_send_list:
+    if len(invitations_to_create) + len(invitations_to_update) > 0:
+        invitations_to_publish = (invitations_to_create | invitations_to_update).values()
         await invitations_events.emit_event_when_workspace_invitations_are_created(
-            workspace=workspace, invitations=invitations_to_send_list
+            workspace=workspace, invitations=invitations_to_publish
         )
 
     return serializers_services.serialize_create_workspace_invitations(

--- a/python/apps/taiga/tests/unit/taiga/projects/invitations/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/invitations/test_services.py
@@ -381,7 +381,7 @@ async def test_create_project_invitations_with_pending_invitations_time_spam(tqm
         fake_invitations_repo.bulk_update_project_invitations.assert_awaited_once()
 
         assert len(tqmanager.pending_jobs) == 0
-        fake_invitations_events.emit_event_when_project_invitations_are_created.assert_not_awaited()
+        fake_invitations_events.emit_event_when_project_invitations_are_created.assert_awaited_once()
 
 
 async def test_create_project_invitations_with_revoked_invitations(tqmanager):
@@ -454,7 +454,7 @@ async def test_create_project_invitations_with_revoked_invitations_time_spam(tqm
         fake_invitations_repo.bulk_update_project_invitations.assert_awaited_once()
 
         assert len(tqmanager.pending_jobs) == 0
-        fake_invitations_events.emit_event_when_project_invitations_are_created.assert_not_awaited()
+        fake_invitations_events.emit_event_when_project_invitations_are_created.assert_awaited_once()
 
 
 async def test_create_project_invitations_by_emails(tqmanager):

--- a/python/apps/taiga/tests/unit/taiga/workspaces/invitations/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/workspaces/invitations/test_services.py
@@ -103,7 +103,7 @@ async def test_create_workspace_invitations_with_pending_invitations_time_spam(t
         fake_invitations_repo.bulk_update_workspace_invitations.assert_awaited_once()
 
         assert len(tqmanager.pending_jobs) == 0
-        fake_invitations_events.emit_event_when_workspace_invitations_are_created.assert_not_awaited()
+        fake_invitations_events.emit_event_when_workspace_invitations_are_created.assert_awaited_once()
 
 
 async def test_create_workspace_invitations_by_emails(tqmanager):


### PR DESCRIPTION
![](https://media.giphy.com/media/52f2uL6Iue6Nq/giphy.gif)

This PR solves the same issue for project and workspace invitations.

Current situation: we only emit event if we have emails to send
Problem: in an spam situation, we don't send email (ok) but we don't emit event either (not ok)

The solution consists on checking if there are new/updated invitations (no matter if they send email) and emit event in this case.

How to test:
- [x] you can reproduce the bug in main (remember, a spam situation)
- [x] check the code
- [x] tests are green
- [x] try the same behaviour in the PR branch, and confirm it doesn't happen

