### PR TITLE
fix(events): i#3805 emit event with proper name

### DIFF
--- a/javascript/apps/taiga/src/app/modules/project/feature-shell/project-feature-shell.component.ts
+++ b/javascript/apps/taiga/src/app/modules/project/feature-shell/project-feature-shell.component.ts
@@ -223,7 +223,7 @@ export class ProjectFeatureShellComponent implements OnDestroy, AfterViewInit {
       });
 
     this.wsService
-      .projectEvents<StoryAssignEvent>('stories_assignments.create')
+      .projectEvents<StoryAssignEvent>('storiesassignments.create')
       .pipe(untilDestroyed(this))
       .subscribe((eventResponse) => {
         const response = eventResponse.event.content.storyAssignment;
@@ -236,7 +236,7 @@ export class ProjectFeatureShellComponent implements OnDestroy, AfterViewInit {
       });
 
     this.wsService
-      .projectEvents<StoryAssignEvent>('stories_assignments.delete')
+      .projectEvents<StoryAssignEvent>('storiesassignments.delete')
       .pipe(untilDestroyed(this))
       .subscribe((eventResponse) => {
         const response = eventResponse.event.content.storyAssignment;

--- a/python/apps/taiga/src/taiga/stories/assignments/events/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/assignments/events/__init__.py
@@ -10,8 +10,8 @@ from taiga.stories.assignments.events.content import CreateStoryAssignmentConten
 from taiga.stories.assignments.models import StoryAssignment
 from taiga.stories.assignments.serializers import StoryAssignmentSerializer
 
-CREATE_STORY_ASSIGNMENT = "stories_assignments.create"
-DELETE_STORY_ASSIGNMENT = "stories_assignments.delete"
+CREATE_STORY_ASSIGNMENT = "storiesassignments.create"
+DELETE_STORY_ASSIGNMENT = "storiesassignments.delete"
 
 
 async def emit_event_when_story_assignment_is_created(story_assignment: StoryAssignment) -> None:

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -737,7 +737,7 @@ Content for:
   ```
 
 
-#### `stories_assignments.create`
+#### `storiesassignments.create`
 
 It happens when a new story assignment has been created.
 
@@ -755,7 +755,7 @@ Content for:
   }
   ```
 
-#### `stories_assignments.delete`
+#### `storiesassignments.delete`
 
 It happens when a story assignment has been deleted.
 


### PR DESCRIPTION
![](https://media.giphy.com/media/sZm7lUPaomGKW0hGjc/giphy.gif)

This PR solves an event naming problem.

How to test:
- [x] check the code
- [x] tests are green
- [x] run everything
- [x] change assignments and check the emitted event
- [x] the frontend is listening to this renamed event properly