### PR TITLE
fix(invitations): i#2517 protect email when possible

### DIFF
--- a/python/apps/taiga/src/taiga/projects/invitations/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/invitations/serializers/__init__.py
@@ -17,7 +17,6 @@ from taiga.users.serializers.nested import UserNestedSerializer
 
 class PublicProjectInvitationSerializer(BaseModel):
     status: ProjectInvitationStatus
-    email: EmailStr
     existing_user: bool
     available_logins: list[str]
     project: ProjectSmallNestedSerializer
@@ -31,7 +30,6 @@ class ProjectInvitationSerializer(BaseModel):
     project: ProjectSmallNestedSerializer
     user: UserNestedSerializer | None
     role: ProjectRoleNestedSerializer
-    email: EmailStr
 
     class Config:
         orm_mode = True

--- a/python/apps/taiga/tests/integration/taiga/projects/invitations/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/projects/invitations/test_api.py
@@ -277,7 +277,6 @@ async def test_accept_user_project_invitation(client):
     response = client.post(f"projects/{project.b64id}/invitations/accept")
     assert response.status_code == status.HTTP_200_OK, response.text
     assert response.json()["user"]["username"] == invited_user.username
-    assert response.json()["email"] == invited_user.email
 
 
 async def test_accept_user_project_not_found(client):

--- a/python/apps/taiga/tests/unit/taiga/projects/invitations/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/invitations/test_services.py
@@ -85,7 +85,6 @@ async def test_get_public_project_invitation_ok():
         )
         fake_auth_services.get_available_user_logins.assert_awaited_once_with(user=invitation.user)
 
-        assert pub_invitation.email == invitation.email
         assert pub_invitation.existing_user is True
         assert pub_invitation.project.name == invitation.project.name
         assert pub_invitation.available_logins == available_user_logins
@@ -107,7 +106,6 @@ async def test_get_public_project_invitation_ok_without_user():
         )
         fake_auth_services.get_available_user_logins.assert_not_awaited()
 
-        assert pub_invitation.email == invitation.email
         assert pub_invitation.existing_user is False
         assert pub_invitation.project.name == invitation.project.name
         assert pub_invitation.available_logins == []

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,8 @@
 {
 	"info": {
-		"_postman_id": "72411ae8-16d8-475f-a19b-020f587a5fac",
+		"_postman_id": "f5d4bb9e-25b0-4238-bb9c-2701cdb38c0b",
 		"name": "taiga-next e2e",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "9835734"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
@@ -4676,7 +4675,6 @@
 									"    pm.expect(invitation).to.have.property(\"id\");",
 									"    pm.expect(invitation).to.have.property(\"user\");",
 									"    pm.expect(invitation).to.have.property(\"role\");",
-									"    pm.expect(invitation).to.have.property(\"email\");",
 									"",
 									"    pm.expect(invitationUser).to.have.property(\"username\");",
 									"    pm.expect(invitationUser).to.have.property(\"fullName\");",
@@ -4945,7 +4943,6 @@
 									"    pm.expect(invitation).to.have.property(\"id\");",
 									"    pm.expect(invitation).to.have.property(\"user\");",
 									"    pm.expect(invitation).to.have.property(\"role\");",
-									"    pm.expect(invitation).to.have.property(\"email\");",
 									"",
 									"    pm.expect(invitationUser).to.have.property(\"username\");",
 									"    pm.expect(invitationUser).to.have.property(\"fullName\");",
@@ -4966,7 +4963,7 @@
 									"    var numOfReturnedUserFields = Object.keys(invitationUser).length;",
 									"    var numOfReturnedRoleFields = Object.keys(invitationRole).length;",
 									"    var numOfReturnedProjectFields = Object.keys(invitationProject).length;",
-									"    pm.expect(numOfReturnedFields).to.equal(5);",
+									"    pm.expect(numOfReturnedFields).to.equal(4);",
 									"    pm.expect(numOfReturnedUserFields).to.equal(3);",
 									"    pm.expect(numOfReturnedRoleFields).to.equal(4);",
 									"    pm.expect(numOfReturnedProjectFields).to.equal(4);",
@@ -5165,7 +5162,6 @@
 									"    pm.expect(invitation).to.have.property(\"id\");",
 									"    pm.expect(invitation).to.have.property(\"user\");",
 									"    pm.expect(invitation).to.have.property(\"role\");",
-									"    pm.expect(invitation).to.have.property(\"email\");",
 									"",
 									"    pm.expect(invitationUser).to.have.property(\"username\");",
 									"    pm.expect(invitationUser).to.have.property(\"fullName\");",
@@ -5186,7 +5182,7 @@
 									"    var numOfReturnedUserFields = Object.keys(invitationUser).length;",
 									"    var numOfReturnedRoleFields = Object.keys(invitationRole).length;",
 									"    var numOfReturnedProjectFields = Object.keys(invitationProject).length;",
-									"    pm.expect(numOfReturnedFields).to.equal(5);",
+									"    pm.expect(numOfReturnedFields).to.equal(4);",
 									"    pm.expect(numOfReturnedUserFields).to.equal(3);",
 									"    pm.expect(numOfReturnedRoleFields).to.equal(4);",
 									"    pm.expect(numOfReturnedProjectFields).to.equal(4);",
@@ -6763,7 +6759,6 @@
 									"    pm.expect(invitation).to.have.property(\"id\");",
 									"    pm.expect(invitation).to.have.property(\"user\");",
 									"    pm.expect(invitation).to.have.property(\"role\");",
-									"    pm.expect(invitation).to.have.property(\"email\");",
 									"",
 									"    pm.expect(invitationUser).to.have.property(\"username\");",
 									"    pm.expect(invitationUser).to.have.property(\"fullName\");",
@@ -6786,7 +6781,7 @@
 									"    var numOfReturnedUserFields = Object.keys(invitationUser).length;",
 									"    var numOfReturnedRoleFields = Object.keys(invitationRole).length;",
 									"    var numOfReturnedProjectFields = Object.keys(invitationProject).length;",
-									"    pm.expect(numOfReturnedFields).to.equal(5);",
+									"    pm.expect(numOfReturnedFields).to.equal(4);",
 									"    pm.expect(numOfReturnedUserFields).to.equal(3);",
 									"    pm.expect(numOfReturnedRoleFields).to.equal(4);",
 									"    pm.expect(numOfReturnedProjectFields).to.equal(4);",

--- a/python/docs/postman/taiga.postman_environment.json
+++ b/python/docs/postman/taiga.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "09cbddbc-4b55-48a9-b70b-e31830d63108",
+	"id": "27b84bcb-1045-479b-9f5c-f6286f79f4d9",
 	"name": "Taiga Next",
 	"values": [
 		{
@@ -156,12 +156,6 @@
 			"enabled": true
 		},
 		{
-			"key": "ws-invit-id\n",
-			"value": "60a31da2-22c1-11ed-ab9d-0242af75836b",
-			"type": "default",
-			"enabled": true
-		},
-		{
 			"key": "ws-invit-id",
 			"value": "",
 			"type": "any",
@@ -174,6 +168,6 @@
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-07-05T14:34:15.106Z",
-	"_postman_exported_using": "Postman/10.14.9"
+	"_postman_exported_at": "2023-07-24T14:56:59.643Z",
+	"_postman_exported_using": "Postman/10.16.0"
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/dxqOkrl29R8ac/giphy.gif)

This PR removes the email from serialization when it's not necessary.

How to review:
- [ ] check the code
- [ ] tests are green
- [ ] no email to see here