### PR TITLE
fix(images): i#2675 the API now prevents from uploading SVG format

### DIFF
--- a/python/apps/taiga/src/taiga/base/utils/images.py
+++ b/python/apps/taiga/src/taiga/base/utils/images.py
@@ -36,7 +36,7 @@ def valid_content_type(uploaded_img: UploadFile) -> bool:
     return uploaded_img.content_type in settings.IMAGES.VALID_CONTENT_TYPES
 
 
-def valid_image_format(uploaded_img: UploadFile) -> bool:
+def valid_image_content(uploaded_img: UploadFile) -> bool:
     try:
         pil_image(uploaded_img.file)
         return True

--- a/python/apps/taiga/src/taiga/conf/images.py
+++ b/python/apps/taiga/src/taiga/conf/images.py
@@ -21,7 +21,6 @@ class ImageSettings(BaseSettings):
         "image/png",
         "image/gif",
         "image/webp",
-        "image/svg+xml",
     ]
 
     class Config:

--- a/python/apps/taiga/src/taiga/projects/projects/api/validators.py
+++ b/python/apps/taiga/src/taiga/projects/projects/api/validators.py
@@ -8,7 +8,7 @@
 
 from fastapi import UploadFile
 from pydantic import conint, constr, validator
-from taiga.base.utils.images import valid_content_type, valid_image_format
+from taiga.base.utils.images import valid_content_type, valid_image_content
 from taiga.base.validators import B64UUID, BaseModel, as_form
 from taiga.permissions.validators import Permissions
 
@@ -31,13 +31,13 @@ class ProjectValidator(BaseModel):
     @validator("logo")
     def check_content_type(cls, v: UploadFile | None) -> UploadFile | None:
         if v:
-            assert valid_content_type(v), "Invalid image format"
+            assert valid_content_type(v), "Invalid image content type"
         return v
 
     @validator("logo")
-    def check_image_format(cls, v: UploadFile | None) -> UploadFile | None:
+    def check_image_content(cls, v: UploadFile | None) -> UploadFile | None:
         if v:
-            assert valid_image_format(v), "Invalid image content"
+            assert valid_image_content(v), "Invalid image content"
         return v
 
 
@@ -50,13 +50,13 @@ class UpdateProjectValidator(BaseModel):
     @validator("logo")
     def check_content_type(cls, v: UploadFile | None) -> UploadFile | None:
         if v:
-            assert valid_content_type(v), "Invalid image format"
+            assert valid_content_type(v), "Invalid image content type"
         return v
 
     @validator("logo")
-    def check_image_format(cls, v: UploadFile | None) -> UploadFile | None:
+    def check_image_content(cls, v: UploadFile | None) -> UploadFile | None:
         if v:
-            assert valid_image_format(v), "Invalid image content"
+            assert valid_image_content(v), "Invalid image content"
         return v
 
 

--- a/python/apps/taiga/tests/unit/taiga/projects/projects/test_validators.py
+++ b/python/apps/taiga/tests/unit/taiga/projects/projects/test_validators.py
@@ -92,7 +92,7 @@ def test_validate_logo_content_type():
         "logo",
         "workspaceId",
     ]
-    expected_error_messages = ["Invalid image format", "field required"]
+    expected_error_messages = ["Invalid image content type", "field required"]
     check_validation_errors(validations_errors, expected_error_fields, expected_error_messages)
 
 


### PR DESCRIPTION
![](https://media.giphy.com/media/qLVGt6Go1dQFp4qVcg/giphy-downsized.gif)

bye bye, SVG

This PR makes the API return an error if the user tries to upload an svg file in the project logo.

How to review:
- [x] check the code
- [x] tests are green
- [x] upload an svg file and check the 422 response from validator