### PR TITLE
feat(user): delete info endpoint

### DIFF
--- a/python/apps/taiga/src/taiga/users/api/__init__.py
+++ b/python/apps/taiga/src/taiga/users/api/__init__.py
@@ -27,7 +27,12 @@ from taiga.users.api.validators import (
     VerifyTokenValidator,
 )
 from taiga.users.models import User
-from taiga.users.serializers import UserSearchSerializer, UserSerializer, VerificationInfoSerializer
+from taiga.users.serializers import (
+    UserDeleteInfoSerializer,
+    UserSearchSerializer,
+    UserSerializer,
+    VerificationInfoSerializer,
+)
 
 # PERMISSIONS
 LIST_USERS_BY_TEXT = IsAuthenticated()
@@ -36,6 +41,7 @@ LIST_USERS_BY_TEXT = IsAuthenticated()
 # HTTP 200 RESPONSES
 ACCESS_TOKEN_200 = responses.http_status_200(model=AccessTokenWithRefreshSerializer)
 VERIFICATION_INFO_200 = responses.http_status_200(model=VerificationInfoSerializer)
+USER_DELETE_INFO_200 = responses.http_status_200(model=UserDeleteInfoSerializer)
 
 
 #####################################################################
@@ -176,6 +182,41 @@ async def update_my_user(request: Request, form: UpdateUserValidator) -> User:
         full_name=form.full_name,
         lang=form.lang,
     )
+
+
+#####################################################################
+# delete user
+#####################################################################
+
+
+# TODO
+
+
+#####################################################################
+# delete info user
+#####################################################################
+
+
+@routes.my.get(
+    "/my/user/delete-info",
+    name="my.user.delete-info",
+    summary="Get user delete info",
+    responses=USER_DELETE_INFO_200 | ERROR_401,
+)
+async def get_user_delete_info(request: Request) -> UserDeleteInfoSerializer:
+    """
+    Get some info before deleting a user.
+
+    This endpoint returns:
+    - A list of workspaces where the user is the only workspace member and the workspace has projects
+    - A list projects where the user is the only project admin and is not the only workspace member
+    or is not workspace member
+    """
+    if request.user.is_anonymous:
+        # NOTE: We force a 401 instead of using the permissions system (which would return a 403)
+        raise ex.AuthorizationError("User is anonymous")
+
+    return await users_services.get_user_delete_info(user=request.user)
 
 
 #####################################################################

--- a/python/apps/taiga/src/taiga/users/serializers/__init__.py
+++ b/python/apps/taiga/src/taiga/users/serializers/__init__.py
@@ -9,6 +9,7 @@ from pydantic import EmailStr
 from taiga.auth.serializers import AccessTokenWithRefreshSerializer
 from taiga.base.serializers import BaseModel
 from taiga.projects.invitations.serializers.nested import ProjectInvitationNestedSerializer
+from taiga.users.serializers.nested import _ProjectWithWorkspaceNestedSerializer, _WorkspaceWithProjectsNestedSerializer
 from taiga.workspaces.invitations.serializers.nested import WorkspaceInvitationNestedSerializer
 
 
@@ -32,6 +33,14 @@ class UserSerializer(UserBaseSerializer):
 class UserSearchSerializer(UserBaseSerializer):
     user_is_member: bool | None
     user_has_pending_invitation: bool | None
+
+    class Config:
+        orm_mode = True
+
+
+class UserDeleteInfoSerializer(BaseModel):
+    workspaces: list[_WorkspaceWithProjectsNestedSerializer]
+    projects: list[_ProjectWithWorkspaceNestedSerializer]
 
     class Config:
         orm_mode = True

--- a/python/apps/taiga/src/taiga/users/serializers/nested.py
+++ b/python/apps/taiga/src/taiga/users/serializers/nested.py
@@ -5,13 +5,39 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
-from taiga.base.serializers import BaseModel
+from taiga.base.serializers import UUIDB64, BaseModel
+from taiga.projects.projects.serializers.mixins import ProjectLogoMixin
+from taiga.projects.projects.serializers.nested import ProjectNestedSerializer
+from taiga.workspaces.workspaces.serializers.nested import WorkspaceSmallNestedSerializer
 
 
 class UserNestedSerializer(BaseModel):
     username: str
     full_name: str
     color: int
+
+    class Config:
+        orm_mode = True
+
+
+class _WorkspaceWithProjectsNestedSerializer(BaseModel):
+    id: UUIDB64
+    name: str
+    slug: str
+    color: int
+    projects: list[ProjectNestedSerializer]
+
+    class Config:
+        orm_mode = True
+
+
+class _ProjectWithWorkspaceNestedSerializer(BaseModel, ProjectLogoMixin):
+    id: UUIDB64
+    name: str
+    slug: str
+    description: str | None = None
+    color: int | None = None
+    workspace: WorkspaceSmallNestedSerializer
 
     class Config:
         orm_mode = True

--- a/python/apps/taiga/src/taiga/users/serializers/services.py
+++ b/python/apps/taiga/src/taiga/users/serializers/services.py
@@ -8,8 +8,11 @@
 
 from taiga.auth.serializers import AccessTokenWithRefreshSerializer
 from taiga.projects.invitations.models import ProjectInvitation
-from taiga.users.serializers import VerificationInfoSerializer
+from taiga.projects.projects.models import Project
+from taiga.users.serializers import UserDeleteInfoSerializer, VerificationInfoSerializer
+from taiga.users.serializers.nested import _WorkspaceWithProjectsNestedSerializer
 from taiga.workspaces.invitations.models import WorkspaceInvitation
+from taiga.workspaces.workspaces.models import Workspace
 
 
 def serialize_verification_info(
@@ -21,4 +24,25 @@ def serialize_verification_info(
         auth=auth,
         project_invitation=project_invitation,
         workspace_invitation=workspace_invitation,
+    )
+
+
+def serialize_workspace_with_projects_nested(
+    workspace: Workspace, projects: list[Project] = []
+) -> _WorkspaceWithProjectsNestedSerializer:
+    return _WorkspaceWithProjectsNestedSerializer(
+        id=workspace.id,
+        name=workspace.name,
+        slug=workspace.slug,
+        color=workspace.color,
+        projects=projects,
+    )
+
+
+def serialize_user_delete_info(
+    workspaces: list[_WorkspaceWithProjectsNestedSerializer], projects: list[Project] = []
+) -> UserDeleteInfoSerializer:
+    return UserDeleteInfoSerializer(
+        workspaces=workspaces,
+        projects=projects,
     )

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -1,8 +1,9 @@
 {
 	"info": {
-		"_postman_id": "77429f0b-3edc-4811-b411-e880c3c03d88",
+		"_postman_id": "f1132cea-3f5f-47c1-ab4d-d4c19d2541ea",
 		"name": "taiga-next",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "9835734"
 	},
 	"item": [
 		{
@@ -261,6 +262,48 @@
 							"path": [
 								"my",
 								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "my user delete info",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/user/delete-info",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"my",
+								"user",
+								"delete-info"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "cc9f25b1-2abe-40e3-b19a-63ccc64c25f2",
+		"_postman_id": "d8b95a15-600f-411c-8269-0a2a65ebbeab",
 		"name": "taiga-next e2e",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "15018493"
+		"_exporter_id": "9835734"
 	},
 	"item": [
 		{
@@ -449,6 +449,111 @@
 							"path": [
 								"my",
 								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200 my.user delete info",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    // Validate response API fields",
+									"    pm.expect(jsonRes).to.have.property(\"workspaces\");",
+									"    pm.expect(jsonRes).to.have.property(\"projects\");",
+									"",
+									"    var workspaces = jsonRes[\"workspaces\"];",
+									"    var projects = jsonRes[\"projects\"];",
+									"",
+									"    if (workspaces.length > 0) {",
+									"        var workspace = workspaces[0];",
+									"        // Validate response API fields",
+									"        pm.expect(workspace).to.have.property(\"id\");",
+									"        pm.expect(workspace).to.have.property(\"name\");",
+									"        pm.expect(workspace).to.have.property(\"slug\");",
+									"        pm.expect(workspace).to.have.property(\"color\");",
+									"        pm.expect(workspace).to.have.property(\"projects\");",
+									"        var numOfReturnedFields = Object.keys(workspace).length;",
+									"        pm.expect(numOfReturnedFields).to.equal(5);",
+									"",
+									"        var workspaceProjects = workspace[\"projects\"]",
+									"        if (workspaceProjects.length > 0) {",
+									"            var workspaceProject = workspaceProjects[0]",
+									"            // Validate response API fields",
+									"            pm.expect(workspaceProject).to.have.property(\"logo\");",
+									"            pm.expect(workspaceProject).to.have.property(\"logoSmall\");",
+									"            pm.expect(workspaceProject).to.have.property(\"logoLarge\");",
+									"            pm.expect(workspaceProject).to.have.property(\"id\");",
+									"            pm.expect(workspaceProject).to.have.property(\"name\");",
+									"            pm.expect(workspaceProject).to.have.property(\"slug\");",
+									"            pm.expect(workspaceProject).to.have.property(\"description\");",
+									"            pm.expect(workspaceProject).to.have.property(\"color\");",
+									"            var numOfReturnedFields = Object.keys(workspaceProject).length;",
+									"            pm.expect(numOfReturnedFields).to.equal(8);",
+									"        }",
+									"    }",
+									"",
+									"    if (projects.length > 0) {",
+									"        var project = projects[0];",
+									"        // Validate response API fields",
+									"        pm.expect(project).to.have.property(\"logo\");",
+									"        pm.expect(project).to.have.property(\"logoSmall\");",
+									"        pm.expect(project).to.have.property(\"logoLarge\");",
+									"        pm.expect(project).to.have.property(\"id\");",
+									"        pm.expect(project).to.have.property(\"name\");",
+									"        pm.expect(project).to.have.property(\"slug\");",
+									"        pm.expect(project).to.have.property(\"description\");",
+									"        pm.expect(project).to.have.property(\"color\");",
+									"        pm.expect(project).to.have.property(\"workspace\");",
+									"        var numOfReturnedFields = Object.keys(project).length;",
+									"        pm.expect(numOfReturnedFields).to.equal(9);",
+									"    }",
+									"",
+									"    // Validate we're not returning more fields than expected",
+									"    var numOfReturnedFields = Object.keys(jsonRes).length;",
+									"    pm.expect(numOfReturnedFields).to.equal(2);",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/user/delete-info",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"my",
+								"user",
+								"delete-info"
 							]
 						}
 					},


### PR DESCRIPTION
## Delete info endpoint

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOWVrZDd4ZXpmbWpxemt1MGVkNjZqZDBneXlxdWY1dmc4bnpjNDJkMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PtYsKeuRNq8JqxatkT/giphy-downsized.gif)

This endpoint is for the "Before deleting..." modal.
Also change validate function in serializers because in this endpoint we need to serialize an id twice.

### How to test:
- [x] Review code
- [x] Tests are green
- [x] Import postman files

You need the next scenary:
- user1 and user2
- ws1 where user1 is the only ws-member
- pj1_ws1 where user1 is the only pj-member (admin)
- pj2_ws1 where user1 is the only pj-admin and user2 is pj-member
- ws2 where user1 and user2 are ws-members
- pj1_ws2 where user1 and user2 are pj-admins
- ws3 where user2 is ws-member
- pj1_ws3 where user1 is the only pj-admin and user2 is pj-member
- ws4 where user1 and user2 are ws-members
- pj1_ws4 where user1 and user2 are pj-admins
- pj2_ws4 where user1 is the only pj-admin and user2 is pj-member
- ws5 where user1 is the only ws-member without projects

In postman:
- [x] Login with user1
- [x] Execute endpoint GET my user delete info
- [x] Check that you have a list of workspaces with ws1 and a list of projects with pj2_ws4 and pj1_ws3
- [x] Check (if you want) thinking in a new scenary with all cases
- [x] Send a jamón of jabugo to Tere or congratulate her 