### PR TITLE
add total-objs to pagination response

### DIFF
--- a/python/apps/taiga/src/taiga/base/api/headers.py
+++ b/python/apps/taiga/src/taiga/base/api/headers.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from typing import Any
+
+from fastapi import Response
+
+
+def set_headers(response: Response, headers: dict[str, Any]) -> None:
+    for k, v in headers.items():
+        response.headers[f"Taiga-{k}"] = str(v)

--- a/python/apps/taiga/src/taiga/main.py
+++ b/python/apps/taiga/src/taiga/main.py
@@ -53,6 +53,7 @@ api.add_middleware(
         "pagination-offset",
         "pagination-limit",
         "pagination-total",
+        "taiga-total-comments",
         CorrelationIdMiddleware.CORRELATION_ID_HEADER_NAME,
     ],
     max_age=1800,

--- a/python/apps/taiga/src/taiga/stories/comments/api.py
+++ b/python/apps/taiga/src/taiga/stories/comments/api.py
@@ -9,6 +9,7 @@ from uuid import UUID
 
 from fastapi import Depends, Query, Response
 from taiga.base.api import AuthRequest
+from taiga.base.api import headers as api_headers
 from taiga.base.api import pagination as api_pagination
 from taiga.base.api.pagination import PaginationQuery
 from taiga.base.api.permissions import check_permissions
@@ -91,13 +92,14 @@ async def list_story_comments(
     """
     story = await get_story_or_404(project_id=project_id, ref=ref)
     await check_permissions(permissions=LIST_STORY_COMMENTS, user=request.user, obj=story)
-    pagination, comments = await comments_services.list_paginated_comments(
+    pagination, total_comments, comments = await comments_services.list_paginated_comments(
         content_object=story,
         offset=pagination_params.offset,
         limit=pagination_params.limit,
         order_by=order_params,
     )
     api_pagination.set_pagination(response=response, pagination=pagination)
+    api_headers.set_headers(response=response, headers={"Total-Comments": total_comments})
     return comments
 
 

--- a/python/apps/taiga/tests/integration/taiga/comments/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/comments/test_repositories.py
@@ -114,3 +114,17 @@ async def test_get_total_comments_by_content_object():
 
     total_comments = await repositories.get_total_comments(filters={"content_object": story1})
     assert total_comments == 2
+
+
+async def test_get_total_comments_not_deleted():
+    story1 = await f.create_story()
+    user = await f.create_user()
+    await f.create_comment(content_object=story1)
+    await f.create_comment(content_object=story1)
+    await f.create_comment(content_object=story1, deleted_by=user, deleted_at=aware_utcnow())
+
+    total_comments = await repositories.get_total_comments(
+        filters={"content_object": story1},
+        excludes={"deleted": True},
+    )
+    assert total_comments == 2


### PR DESCRIPTION
![](https://media.giphy.com/media/4ahFliSdvT3iIgjq6k/giphy.gif)

This PR adds a new header in the response of list comments, so the user can have both:
- total comments including deleted (for pagination purposes)
- total comments "only active" (for user purposes)

How to review:
- [x] check the code
- [x] tests are green
- [x] go to a story with comments, and delete some of them
- [x] request the list of comments and check the response headers where 1) the pagination-total is the total comments including deleted and 2) the taiga-total-comments header is the total of comments that haven't been deleted