### PR TITLE
issue(b64uuid): i#3907 fix returning uuids on 404 errors

### DIFF
--- a/python/apps/taiga/src/taiga/base/validators/fields.py
+++ b/python/apps/taiga/src/taiga/base/validators/fields.py
@@ -49,12 +49,8 @@ class B64UUID(UUID):
         yield cls.validate
 
     @classmethod
-    def validate(cls, value: str) -> UUID | None:
-        try:
-            return decode_b64str_to_uuid(value)
-        except ValueError:
-            # if it's not a valid base64 string return None to force a 404 (Not Found) response
-            return None
+    def validate(cls, value: str) -> UUID:
+        return decode_b64str_to_uuid(value)
 
 
 class FileField(AnyHttpUrl):

--- a/python/apps/taiga/src/taiga/projects/invitations/api/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/invitations/api/__init__.py
@@ -54,7 +54,7 @@ PUBLIC_PROJECT_INVITATION_200 = responses.http_status_200(model=PublicProjectInv
     "/projects/{id}/invitations",
     name="project.invitations.create",
     summary="Create project invitations",
-    responses=CREATE_PROJECT_INVITATIONS_200 | ERROR_400 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=CREATE_PROJECT_INVITATIONS_200 | ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 # TODO: remove "Query" from the "id" parameter
 async def create_project_invitations(
@@ -85,7 +85,7 @@ async def create_project_invitations(
     name="project.invitations.list",
     summary="List project pending invitations",
     response_model=list[ProjectInvitationSerializer],
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_project_invitations(
     id: B64UUID,
@@ -135,7 +135,7 @@ async def get_public_project_invitation(token: str) -> PublicProjectInvitationSe
     name="project.invitations.update",
     summary="Update project invitation",
     response_model=ProjectInvitationSerializer,
-    responses=ERROR_422 | ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def update_project_invitation(
     id: UUID,
@@ -162,7 +162,7 @@ async def update_project_invitation(
     name="project.invitations.resend",
     summary="Resend project invitation",
     response_class=Response,
-    responses=ERROR_422 | ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def resend_project_invitation(
@@ -189,7 +189,7 @@ async def resend_project_invitation(
     "/projects/{id}/invitations/revoke",
     name="project.invitations.revoke",
     summary="Revoke project invitation",
-    responses=ERROR_422 | ERROR_400 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
     response_class=Response,
     status_code=status.HTTP_204_NO_CONTENT,
 )
@@ -218,7 +218,7 @@ async def revoke_project_invitation(
     name="project.invitations.accept",
     summary="Accept a project invitation using a token",
     response_model=ProjectInvitationSerializer,
-    responses=ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def accept_project_invitation_by_token(request: AuthRequest, token: str) -> ProjectInvitation:
     """
@@ -234,7 +234,7 @@ async def accept_project_invitation_by_token(request: AuthRequest, token: str) -
     name="project.my.invitations.accept",
     summary="Accept a project invitation for authenticated users",
     response_model=ProjectInvitationSerializer,
-    responses=ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def accept_project_invitation_by_project(id: B64UUID, request: AuthRequest) -> ProjectInvitation:
     """

--- a/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/memberships/api/__init__.py
@@ -90,7 +90,7 @@ async def update_project_membership(
     "/projects/{id}/memberships/{username}",
     name="project.memberships.delete",
     summary="Delete project membership",
-    responses=ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_project_membership(id: B64UUID, username: str, request: AuthRequest) -> None:

--- a/python/apps/taiga/src/taiga/projects/projects/api/__init__.py
+++ b/python/apps/taiga/src/taiga/projects/projects/api/__init__.py
@@ -82,7 +82,7 @@ async def create_project(
     name="workspace.projects.list",
     summary="List workspace projects",
     response_model=list[ProjectSummarySerializer],
-    responses=ERROR_403 | ERROR_404,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_workspace_projects(workspace_id: B64UUID, request: AuthRequest) -> list[Project]:
     """
@@ -98,7 +98,7 @@ async def list_workspace_projects(workspace_id: B64UUID, request: AuthRequest) -
     name="workspace.invited-projects.list",
     summary="List of projects in a workspace where the user is invited",
     response_model=list[ProjectSummarySerializer],
-    responses=ERROR_403 | ERROR_404,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_workspace_invited_projects(workspace_id: B64UUID, request: AuthRequest) -> list[Project]:
     """
@@ -118,7 +118,7 @@ async def list_workspace_invited_projects(workspace_id: B64UUID, request: AuthRe
     "/projects/{id}",
     name="project.get",
     summary="Get project",
-    responses=PROJECT_DETAIL_200 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=PROJECT_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def get_project(id: B64UUID, request: AuthRequest) -> ProjectDetailSerializer:
@@ -136,7 +136,7 @@ async def get_project(id: B64UUID, request: AuthRequest) -> ProjectDetailSeriali
     name="project.public-permissions.list",
     summary="List project public permissions",
     response_model=list[str],
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_project_public_permissions(id: B64UUID, request: AuthRequest) -> list[str]:
     """
@@ -157,7 +157,7 @@ async def list_project_public_permissions(id: B64UUID, request: AuthRequest) -> 
     "/projects/{id}",
     name="project.update",
     summary="Update project",
-    responses=PROJECT_DETAIL_200 | ERROR_400 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=PROJECT_DETAIL_200 | ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def update_project(
@@ -180,7 +180,7 @@ async def update_project(
     name="project.public-permissions.put",
     summary="Edit project public permissions",
     response_model=list[str],
-    responses=ERROR_400 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def update_project_public_permissions(
     id: B64UUID,
@@ -206,7 +206,7 @@ async def update_project_public_permissions(
     "/projects/{id}",
     name="projects.delete",
     summary="Delete project",
-    responses=ERROR_404 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_project(id: B64UUID, request: AuthRequest) -> None:
@@ -229,7 +229,7 @@ async def delete_project(id: B64UUID, request: AuthRequest) -> None:
     name="my.projects.permissions.list",
     summary="List my project permissions",
     response_model=list[str],
-    responses=ERROR_404,
+    responses=ERROR_404 | ERROR_422,
 )
 async def list_my_project_permissions(id: B64UUID, request: AuthRequest) -> list[str]:
     """
@@ -247,6 +247,6 @@ async def list_my_project_permissions(id: B64UUID, request: AuthRequest) -> list
 async def get_project_or_404(id: UUID) -> Project:
     project = await projects_services.get_project(id=id)
     if project is None:
-        raise ex.NotFoundError(f"Project {id} does not exist")
+        raise ex.NotFoundError("Project does not exist")
 
     return project

--- a/python/apps/taiga/src/taiga/projects/roles/api.py
+++ b/python/apps/taiga/src/taiga/projects/roles/api.py
@@ -36,7 +36,7 @@ UPDATE_PROJECT_ROLE_PERMISSIONS = IsProjectAdmin()
     name="project.roles.list",
     summary="Get project roles permissions",
     response_model=list[ProjectRoleSerializer],
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_project_roles(project_id: B64UUID, request: AuthRequest) -> list[ProjectRole]:
     """
@@ -58,7 +58,7 @@ async def list_project_roles(project_id: B64UUID, request: AuthRequest) -> list[
     name="project.roles.permissions.put",
     summary="Edit project roles permissions",
     response_model=ProjectRoleSerializer,
-    responses=ERROR_400 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def update_project_role_permissions(
     project_id: B64UUID,

--- a/python/apps/taiga/src/taiga/stories/assignments/api/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/assignments/api/__init__.py
@@ -36,7 +36,7 @@ DELETE_STORY_ASSIGNMENT = HasPerm("modify_story")
     name="project.story.assignments.create",
     summary="Create story assignment",
     response_model=StoryAssignmentSerializer,
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def create_story_assignment(
     project_id: B64UUID,
@@ -64,7 +64,7 @@ async def create_story_assignment(
     "/projects/{project_id}/stories/{ref}/assignments/{username}",
     name="project.story.assignments.delete",
     summary="Delete story assignment",
-    responses=ERROR_404 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_story_assignment(

--- a/python/apps/taiga/src/taiga/stories/comments/api.py
+++ b/python/apps/taiga/src/taiga/stories/comments/api.py
@@ -45,7 +45,7 @@ DELETE_STORY_COMMENT = IsNotDeleted() & (
     name="project.story.comments.create",
     summary="Create story comment",
     response_model=CommentSerializer,
-    responses=ERROR_403 | ERROR_422 | ERROR_404,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def create_story_comments(
     project_id: B64UUID,
@@ -77,7 +77,7 @@ async def create_story_comments(
     name="project.story.comments.list",
     summary="List story comments",
     response_model=list[CommentSerializer],
-    responses=ERROR_403 | ERROR_422 | ERROR_404,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_story_comments(
     project_id: B64UUID,
@@ -113,7 +113,7 @@ async def list_story_comments(
     name="project.story.comments.update",
     summary="Update story comment",
     response_model=CommentSerializer,
-    responses=ERROR_403 | ERROR_422 | ERROR_404,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def update_story_comments(
     project_id: B64UUID,
@@ -148,7 +148,7 @@ async def update_story_comments(
     name="project.story.comments.delete",
     summary="Delete story comment",
     response_model=CommentSerializer,
-    responses=ERROR_403 | ERROR_404,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def delete_story_comment(
     project_id: B64UUID,

--- a/python/apps/taiga/src/taiga/stories/mediafiles/api.py
+++ b/python/apps/taiga/src/taiga/stories/mediafiles/api.py
@@ -31,7 +31,7 @@ MEDIAFILE_DETAIL_200 = responses.http_status_200(model=MediafileSerializer)
     "/projects/{project_id}/stories/{ref}/mediafiles",
     name="project.story.mediafiles.create",
     summary="Create mediafiles and attach to an story",
-    responses=MEDIAFILE_DETAIL_200 | ERROR_403 | ERROR_422 | ERROR_404,
+    responses=MEDIAFILE_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def create_story_mediafiles(

--- a/python/apps/taiga/src/taiga/stories/stories/api/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/api/__init__.py
@@ -47,7 +47,7 @@ REORDER_STORIES_200 = responses.http_status_200(model=ReorderStoriesSerializer)
     "/projects/{project_id}/workflows/{workflow_slug}/stories",
     name="project.stories.create",
     summary="Create an story",
-    responses=STORY_DETAIL_200 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=STORY_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def create_story(
@@ -81,7 +81,7 @@ async def create_story(
     "/projects/{project_id}/workflows/{workflow_slug}/stories",
     name="project.stories.list",
     summary="List stories",
-    responses=LIST_STORY_SUMMARY_200 | ERROR_404 | ERROR_403,
+    responses=LIST_STORY_SUMMARY_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def list_stories(
@@ -118,7 +118,7 @@ async def list_stories(
     "/projects/{project_id}/stories/{ref}",
     name="project.stories.get",
     summary="Get story",
-    responses=STORY_DETAIL_200 | ERROR_404 | ERROR_403,
+    responses=STORY_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def get_story(project_id: B64UUID, ref: int, request: AuthRequest) -> StoryDetailSerializer:
@@ -140,7 +140,7 @@ async def get_story(project_id: B64UUID, ref: int, request: AuthRequest) -> Stor
     "/projects/{project_id}/stories/{ref}",
     name="project.stories.update",
     summary="Update story",
-    responses=STORY_DETAIL_200 | ERROR_404 | ERROR_403,
+    responses=STORY_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def update_story(
@@ -177,7 +177,7 @@ async def update_story(
     "/projects/{project_id}/workflows/{workflow_slug}/stories/reorder",
     name="project.stories.reorder",
     summary="Reorder stories",
-    responses=REORDER_STORIES_200 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=REORDER_STORIES_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def reorder_stories(
@@ -210,7 +210,7 @@ async def reorder_stories(
     "/projects/{project_id}/stories/{ref}",
     name="project.stories.delete",
     summary="Delete story",
-    responses=ERROR_404 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_story(
@@ -235,6 +235,6 @@ async def delete_story(
 async def get_story_or_404(project_id: UUID, ref: int) -> Story:
     story = await stories_services.get_story(project_id=project_id, ref=ref)
     if story is None:
-        raise ex.NotFoundError(f"Story {ref} does not exist in project {project_id}")
+        raise ex.NotFoundError(f"Story {ref} does not exist in the project")
 
     return story

--- a/python/apps/taiga/src/taiga/users/api/__init__.py
+++ b/python/apps/taiga/src/taiga/users/api/__init__.py
@@ -15,7 +15,7 @@ from taiga.base.api.pagination import PaginationQuery
 from taiga.base.api.permissions import check_permissions
 from taiga.base.validators import B64UUID
 from taiga.exceptions import api as ex
-from taiga.exceptions.api.errors import ERROR_400, ERROR_401, ERROR_422
+from taiga.exceptions.api.errors import ERROR_400, ERROR_401, ERROR_403, ERROR_422
 from taiga.permissions import IsAuthenticated
 from taiga.routers import routes
 from taiga.users import services as users_services
@@ -103,6 +103,7 @@ async def verify_user(form: VerifyTokenValidator) -> VerificationInfoSerializer:
     summary="List all users matching a full text search, ordered (when provided) by their closeness"
     " to a project or a workspace.",
     response_model=list[UserSearchSerializer],
+    responses=ERROR_403 | ERROR_422,
 )
 async def list_users_by_text(
     request: Request,

--- a/python/apps/taiga/src/taiga/workflows/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/api/__init__.py
@@ -49,7 +49,7 @@ REORDER_WORKFLOW_STATUSES_200 = responses.http_status_200(model=ReorderWorkflowS
     "/projects/{id}/workflows",
     name="project.workflow.list",
     summary="List workflows",
-    responses=LIST_WORKFLOW_200 | ERROR_404 | ERROR_403,
+    responses=LIST_WORKFLOW_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def list_workflows(id: B64UUID, request: Request) -> list[WorkflowSerializer]:
@@ -70,7 +70,7 @@ async def list_workflows(id: B64UUID, request: Request) -> list[WorkflowSerializ
     "/projects/{id}/workflows/{workflow_slug}",
     name="project.workflow.get",
     summary="Get project workflow",
-    responses=GET_WORKFLOW_200 | ERROR_404 | ERROR_403,
+    responses=GET_WORKFLOW_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def get_workflow(
@@ -109,7 +109,7 @@ async def get_workflow_or_404(project_id: UUID, workflow_slug: str) -> Workflow:
     name="project.workflowstatus.create",
     summary="Create a workflow status",
     response_model=WorkflowStatusSerializer,
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def create_workflow_status(
     project_id: B64UUID,
@@ -140,7 +140,7 @@ async def create_workflow_status(
     name="project.workflowstatus.update",
     summary="Update workflow status",
     response_model=WorkflowStatusSerializer,
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def update_workflow_status(
     id: B64UUID,
@@ -170,7 +170,7 @@ async def update_workflow_status(
     "/projects/{project_id}/workflows/{workflow_slug}/statuses/reorder",
     name="project.workflowstatus.reorder",
     summary="Reorder workflow statuses",
-    responses=REORDER_WORKFLOW_STATUSES_200 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=REORDER_WORKFLOW_STATUSES_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def reorder_workflow_statuses(
@@ -201,7 +201,7 @@ async def reorder_workflow_statuses(
     "/projects/{project_id}/workflows/{workflow_slug}/statuses/{id}",
     name="project.workflowstatus.delete",
     summary="Delete a workflow status",
-    responses=ERROR_404 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_workflow_status(
@@ -227,7 +227,7 @@ async def delete_workflow_status(
 
     await workflows_services.delete_workflow_status(
         workflow_status=workflow_status,
-        target_status_id=query_params.move_to,
+        target_status_id=query_params.move_to,  # type: ignore
     )
 
 
@@ -241,6 +241,6 @@ async def get_workflow_status_or_404(project_id: UUID, workflow_slug: str, id: U
         project_id=project_id, workflow_slug=workflow_slug, id=id
     )
     if workflow_status is None:
-        raise ex.NotFoundError(f"Workflow status {id} does not exist")
+        raise ex.NotFoundError("Workflow status does not exist")
 
     return workflow_status

--- a/python/apps/taiga/src/taiga/workflows/services/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/services/__init__.py
@@ -241,7 +241,7 @@ async def delete_workflow_status(workflow_status: WorkflowStatus, target_status_
     status of the same workflow.
 
     :param workflow_status: the workflow status to delete
-    :param target_status: the workflow status's id to which move the stories from the status being deleted
+    :param target_status_id: the workflow status's id to which move the stories from the status being deleted
         - if not received, all the workflow status and its contained stories will be deleted
         - if received, the workflow status will be deleted but its contained stories won't (they will be first moved to
          the specified status)

--- a/python/apps/taiga/src/taiga/workspaces/invitations/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/invitations/api/__init__.py
@@ -44,7 +44,7 @@ PUBLIC_WORKSPACE_INVITATION_200 = responses.http_status_200(model=PublicWorkspac
     "/workspaces/{id}/invitations",
     name="workspace.invitations.create",
     summary="Create workspace invitations",
-    responses=CREATE_WORKSPACE_INVITATIONS_200 | ERROR_400 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=CREATE_WORKSPACE_INVITATIONS_200 | ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def create_workspace_invitations(
     id: B64UUID,
@@ -72,7 +72,7 @@ async def create_workspace_invitations(
     name="workspace.invitations.list",
     summary="List workspace pending invitations",
     response_model=list[WorkspaceInvitationSerializer],
-    responses=ERROR_404 | ERROR_422 | ERROR_403,
+    responses=ERROR_403 | ERROR_404 | ERROR_422,
 )
 async def list_workspace_invitations(
     id: B64UUID,

--- a/python/apps/taiga/src/taiga/workspaces/workspaces/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workspaces/workspaces/api/__init__.py
@@ -41,7 +41,7 @@ LIST_WORKSPACE_DETAIL_200 = responses.http_status_200(model=list[WorkspaceDetail
     "/workspaces",
     name="workspaces.post",
     summary="Create workspace",
-    responses=WORKSPACE_DETAIL_200 | ERROR_422 | ERROR_403,
+    responses=WORKSPACE_DETAIL_200 | ERROR_403 | ERROR_422,
     response_model=None,
 )
 async def create_workspace(form: WorkspaceValidator, request: AuthRequest) -> WorkspaceSerializer:
@@ -80,7 +80,7 @@ async def list_my_workspaces(request: AuthRequest) -> list[WorkspaceDetailSerial
     "/workspaces/{id}",
     name="workspaces.get",
     summary="Get workspace",
-    responses=WORKSPACE_DETAIL_200 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=WORKSPACE_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def get_workspace(id: B64UUID, request: AuthRequest) -> WorkspaceSerializer:
@@ -96,7 +96,7 @@ async def get_workspace(id: B64UUID, request: AuthRequest) -> WorkspaceSerialize
     "/my/workspaces/{id}",
     name="my.workspaces.get",
     summary="Get the overview of a workspace to which I belong",
-    responses=WORKSPACE_DETAIL_200 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=WORKSPACE_DETAIL_200 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def get_my_workspace(id: B64UUID, request: AuthRequest) -> WorkspaceDetailSerializer:
@@ -119,7 +119,7 @@ async def get_my_workspace(id: B64UUID, request: AuthRequest) -> WorkspaceDetail
     "/workspaces/{id}",
     name="workspace.update",
     summary="Update workspace",
-    responses=WORKSPACE_200 | ERROR_400 | ERROR_404 | ERROR_422 | ERROR_403,
+    responses=WORKSPACE_200 | ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
     response_model=None,
 )
 async def update_workspace(
@@ -146,7 +146,7 @@ async def update_workspace(
     "/workspaces/{id}",
     name="workspace.delete",
     summary="Delete workspace",
-    responses=ERROR_400 | ERROR_404 | ERROR_403,
+    responses=ERROR_400 | ERROR_403 | ERROR_404 | ERROR_422,
     status_code=status.HTTP_204_NO_CONTENT,
 )
 async def delete_workspace(id: B64UUID, request: AuthRequest) -> None:

--- a/python/apps/taiga/tests/integration/taiga/stories/mediafiles/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/mediafiles/test_api.py
@@ -8,15 +8,17 @@
 import pytest
 from fastapi import status
 from tests.utils import factories as f
+from tests.utils.bad_params import INVALID_B64ID, INVALID_REF, NOT_EXISTING_B64ID, NOT_EXISTING_REF
 
 pytestmark = pytest.mark.django_db(transaction=True)
+
 
 ##########################################################
 # POST /projects/<b64id>/stories/<ref>/stories/mediafiles
 ##########################################################
 
 
-async def test_create_story_mediafile_success(client):
+async def test_create_story_mediafile_200_ok(client):
     project = await f.create_project()
     story = await f.create_story(project=project)
     user = project.created_by
@@ -39,7 +41,7 @@ async def test_create_story_mediafile_success(client):
     assert len(response.json()) == 3
 
 
-async def test_create_story_mediafile_error_no_permissions(client):
+async def test_create_story_mediafile_403_forbidden_error_no_permissions(client):
     project = await f.create_project(public_permissions=[])
     story = await f.create_story(project=project)
     user = await f.create_user()
@@ -57,19 +59,7 @@ async def test_create_story_mediafile_error_no_permissions(client):
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
 
 
-async def test_create_story_mediafile_error_bad_request(client):
-    project = await f.create_project()
-    story = await f.create_story(project=project)
-    user = project.created_by
-
-    client.login(user)
-    response = client.post(
-        f"/projects/{project.b64id}/stories/{story.ref}/mediafiles",
-    )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
-
-
-async def test_create_story_mediafile_error_story_not_found(client):
+async def test_create_story_mediafile_404_not_found_project_b64id(client):
     project = await f.create_project()
     story = await f.create_story(project=project)
     user = project.created_by
@@ -81,13 +71,71 @@ async def test_create_story_mediafile_error_story_not_found(client):
 
     client.login(user)
     response = client.post(
-        f"/projects/{project.b64id}/stories/9999/mediafiles",
+        f"/projects/{NOT_EXISTING_B64ID}/stories/{story.ref}/mediafiles",
         files=files,
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
 
+
+async def test_create_story_mediafile_404_not_found_story_ref(client):
+    project = await f.create_project()
+    user = project.created_by
+    file = f.build_image_file("image")
+
+    files = [
+        ("files", (file.name, file, "image/png")),
+    ]
+
+    client.login(user)
     response = client.post(
-        f"/projects/aaaa/stories/{story.ref}/mediafiles",
+        f"/projects/{project.b64id}/stories/{NOT_EXISTING_REF}/mediafiles",
         files=files,
     )
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
+
+
+async def test_create_story_mediafile_422_unprocessable_project_b64id(client):
+    project = await f.create_project()
+    story = await f.create_story(project=project)
+    user = project.created_by
+    file = f.build_image_file("image")
+
+    files = [
+        ("files", (file.name, file, "image/png")),
+    ]
+
+    client.login(user)
+    response = client.post(
+        f"/projects/{INVALID_B64ID}/stories/{story.ref}/mediafiles",
+        files=files,
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+
+
+async def test_create_story_mediafile_422_unprocessable_story_ref(client):
+    project = await f.create_project()
+    user = project.created_by
+    file = f.build_image_file("image")
+
+    files = [
+        ("files", (file.name, file, "image/png")),
+    ]
+
+    client.login(user)
+    response = client.post(
+        f"/projects/{project.b64id}/stories/{INVALID_REF}/mediafiles",
+        files=files,
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+
+
+async def test_create_story_mediafile_422_unprocessable_bad_request(client):
+    project = await f.create_project()
+    story = await f.create_story(project=project)
+    user = project.created_by
+
+    client.login(user)
+    response = client.post(
+        f"/projects/{project.b64id}/stories/{story.ref}/mediafiles",
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text

--- a/python/apps/taiga/tests/integration/taiga/workspaces/invitations/test_api.py.orig
+++ b/python/apps/taiga/tests/integration/taiga/workspaces/invitations/test_api.py.orig
@@ -142,7 +142,13 @@ async def test_list_workspaces_invitations_403_forbidden_no_permissions(client):
 async def test_list_workspaces_404_not_found_workspace_b64id(client):
     workspace = await f.create_workspace()
     client.login(workspace.created_by)
-    response = client.get(f"/workspaces/{NOT_EXISTING_B64ID}/invitations")
+<<<<<<< HEAD
+    response = client.get("/workspaces/non-existing-id/invitations")
+=======
+    offset = 0
+    limit = 1
+    response = client.get(f"/workspaces/{NOT_EXISTING_B64ID}/invitations?offset={offset}&limit={limit}")
+>>>>>>> 3982c48ca (issue(b64uuid): i#3907 fix returning uuids on 404 errors)
     assert response.status_code == status.HTTP_404_NOT_FOUND, response.text
 
 

--- a/python/apps/taiga/tests/unit/taiga/base/test_validators.py
+++ b/python/apps/taiga/tests/unit/taiga/base/test_validators.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # Copyright (c) 2023-present Kaleidos INC
+
 from uuid import UUID
 
 import pytest
@@ -45,15 +46,22 @@ class B64UUIDValidator(BaseModel):
     b64id: B64UUID
 
 
+def test_b64id_ok():
+    validator = B64UUIDValidator(b64id="6JgsbGyoEe2VExhWgGrI2w")
+
+    assert validator.b64id == UUID("e8982c6c-6ca8-11ed-9513-1856806ac8db")
+
+
 @pytest.mark.parametrize(
     "b64id, result",
     [
         ("", None),
         ("6Jgsbshort", None),
         ("@#!", None),
-        ("6JgsbGyoEe2VExhWgGrI2w", UUID("e8982c6c-6ca8-11ed-9513-1856806ac8db")),
     ],
 )
-def test_b64id(b64id: str | None, result: UUID | None):
-    validator = B64UUIDValidator(b64id=b64id)
-    assert validator.b64id == result
+def test_b64id_validation_error(b64id: str | None, result: UUID | None):
+    with pytest.raises(ValidationError):
+        validator = B64UUIDValidator(b64id=b64id)
+
+        assert validator.b64id == result

--- a/python/apps/taiga/tests/unit/taiga/stories/stories/test_validators.py
+++ b/python/apps/taiga/tests/unit/taiga/stories/stories/test_validators.py
@@ -8,6 +8,7 @@
 import pytest
 from pydantic import ValidationError
 from taiga.stories.stories.api.validators import ReorderStoriesValidator, ReorderValidator
+from tests.utils.bad_params import NOT_EXISTING_B64ID
 
 #######################################################
 # ReorderValidator
@@ -47,13 +48,13 @@ async def test_reorder_validator_fail():
 
 async def test_reorder_stories_validator_ok():
     reorder = ReorderValidator(place="after", ref=2)
-    assert ReorderStoriesValidator(status="status", stories=[1, 2, 3], reorder=reorder)
-    assert ReorderStoriesValidator(status="status", stories=[1, 2, 3])
+    assert ReorderStoriesValidator(status=NOT_EXISTING_B64ID, stories=[1, 2, 3], reorder=reorder)
+    assert ReorderStoriesValidator(status=NOT_EXISTING_B64ID, stories=[1, 2, 3])
 
 
 async def test_reorder_stories_validator_fail():
     with pytest.raises(ValidationError) as exc_info:
-        ReorderStoriesValidator(status="status", stories=[])
+        ReorderStoriesValidator(status=NOT_EXISTING_B64ID, stories=[])
     assert exc_info.value.errors() == [
         {
             "ctx": {"limit_value": 1},
@@ -70,7 +71,7 @@ async def test_reorder_stories_validator_fail():
     ]
 
     with pytest.raises(ValidationError) as exc_info:
-        ReorderStoriesValidator(status="status", stories=[1], reorder={"place": "nope", "ref": 3})
+        ReorderStoriesValidator(status=NOT_EXISTING_B64ID, stories=[1], reorder={"place": "nope", "ref": 3})
     assert exc_info.value.errors() == [
         {"loc": ("reorder", "place"), "msg": "Place should be 'after' or 'before'", "type": "assertion_error"}
     ]

--- a/python/apps/taiga/tests/utils/bad_params.py
+++ b/python/apps/taiga/tests/utils/bad_params.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+# not existing but valid parameters
+NOT_EXISTING_REF = "9999"
+NOT_EXISTING_SLUG = "unexisting_slug"
+NOT_EXISTING_B64ID = "ZZZZZZZZZZZZZZZZZZZZZZ"
+
+# invalid parameters
+INVALID_REF = "abc"
+INVALID_B64ID = "ZZZZZZZ"

--- a/python/docs/conventions/test_api.convetions.md
+++ b/python/docs/conventions/test_api.convetions.md
@@ -1,0 +1,29 @@
+# Test API conventions
+
+- Each test must validate just one thing.
+- Use the minimal required objects to reproduce the test scenario
+- API tests must check all the HTTP statuses they may return (requiring at least an individual test)
+- It's not required to test all the cases that may return the same status error, just the interesting ones.
+  - Don't test Pydantic ("abc" and -1 are not valid integers)
+  - Test any custom validation
+  - Test any url param that may return the same error
+- API tests should be first-ordered following the API grouping criteria: list > create > get detail > update > delete.
+- API tests should be secondly ordered accordingly to their numerical HTTP status code (200>204>400>403>404 ...)
+- API test will follow this naming convention: `test_<api method>_<HTTP status code><HTTP status message>[_<free_text>]`
+
+- Example:
+```python
+async def test_create_project_200_ok(client):
+async def test_create_project_400_bad_request(client):
+async def test_create_project_403_forbidden_not_ws_member(client):
+async def test_create_project_403_forbidden_anonymous(client):
+async def test_create_project_422_unprocessable(client):
+```
+- Make use of the constants defined in `tests.utils.bad_params.py` as your wrong intended parameters. If you required a new one, please add it to this file.
+```python
+NOT_EXISTING_SLUG = "wrong_slug"
+INVALID_REF = "abc"
+NOT_EXISTING_REF = "9999"
+INVALID_B64ID = "ZZZZZZZ"
+NOT_EXISTING_B64ID = "ZZZZZZZZZZZZZZZZZZZZZZ"
+```


### PR DESCRIPTION
This PR fixes returning uuids on the 404 errors where those endpoints were really managing b64uuids on their requests. 

![gif](https://media.giphy.com/media/zJXUT90Kjz4Xnlpe7M/giphy.gif)

### Solution approach

The B64UUID's validator has been changed to remove the try/expect protection when trying to get the UUID, and letting the pydantic ValidationError to arise.
As result, when we previously return just a 404, we may also return a 422 when the provided b64id is not valid.

### Effective changes

- The Openapi errors in the affected endpoints has been fixed to include the new 422 response (and to follow the new convention)
- Tests have been fixed, including new tests for the new 422 cases (and changed to follow the new convenction)
- Error message in the responses won't show any id (the error originally)  because there's not a 1-to-1 relationship between `b64uuid's` and `uuid's` .
- It's been included a new "bad_param.py" file for wrong parameters to be reused in the tests
- It's been included a new convention for developing API tests

### What to test
- [x] Check the code
- [x] Review the new convention (`test_api.convetions.py`)
- [x] Tests are green

The endpoints including any b64id path param (almost everyone), do return:
- [x] 422 when the b64id it's invalid
- [x] 404 when the related resource doesn't exist
- [x] any previous response