### PR TITLE
i#3923 fix delete_comment service

### DIFF
--- a/python/apps/taiga/src/taiga/comments/events.py
+++ b/python/apps/taiga/src/taiga/comments/events.py
@@ -8,19 +8,18 @@
 from typing import Awaitable, Protocol
 
 from taiga.comments.models import Comment
-from taiga.projects.projects.models import Project
 
 
 class EventOnCreateCallable(Protocol):
-    def __call__(self, project: Project, comment: Comment) -> Awaitable[None]:
+    def __call__(self, comment: Comment) -> Awaitable[None]:
         ...
 
 
 class EventOnUpdateCallable(Protocol):
-    def __call__(self, project: Project, comment: Comment) -> Awaitable[None]:
+    def __call__(self, comment: Comment) -> Awaitable[None]:
         ...
 
 
 class EventOnDeleteCallable(Protocol):
-    def __call__(self, project: Project, comment: Comment) -> Awaitable[None]:
+    def __call__(self, comment: Comment) -> Awaitable[None]:
         ...

--- a/python/apps/taiga/src/taiga/comments/services.py
+++ b/python/apps/taiga/src/taiga/comments/services.py
@@ -36,7 +36,7 @@ async def create_comment(
     )
 
     if event_on_create:
-        await event_on_create(project=comment.project, comment=comment)
+        await event_on_create(comment=comment)
 
     return comment
 
@@ -98,7 +98,7 @@ async def update_comment(
     updated_comment = await comments_repositories.update_comment(comment=comment, values=values)
 
     if event_on_update:
-        await event_on_update(project=story.project, comment=updated_comment)
+        await event_on_update(comment=updated_comment)
 
     return updated_comment
 
@@ -123,6 +123,6 @@ async def delete_comment(
     )
 
     if event_on_delete:
-        await event_on_delete(project=updated_comment.project, comment=updated_comment)
+        await event_on_delete(comment=updated_comment)
 
     return updated_comment

--- a/python/apps/taiga/src/taiga/permissions/services.py
+++ b/python/apps/taiga/src/taiga/permissions/services.py
@@ -25,12 +25,12 @@ async def is_project_admin(user: AnyUser, obj: Any) -> bool:
     if user.is_anonymous:
         return False
 
+    if user.is_superuser:
+        return True
+
     project = await _get_object_project(obj)
     if project is None:
         return False
-
-    if user.is_superuser:
-        return True
 
     role = await pj_roles_repositories.get_project_role(filters={"user_id": user.id, "project_id": project.id})
     return role.is_admin if role else False
@@ -49,12 +49,12 @@ async def is_workspace_member(user: AnyUser, obj: Any) -> bool:
     if user.is_anonymous:
         return False
 
+    if user.is_superuser:
+        return True
+
     workspace = await _get_object_workspace(obj)
     if workspace is None:
         return False
-
-    if user.is_superuser:
-        return True
 
     workspace_membership = await workspace_memberships_repositories.get_workspace_membership(
         filters={"user_id": user.id, "workspace_id": workspace.id},

--- a/python/apps/taiga/src/taiga/stories/comments/api.py
+++ b/python/apps/taiga/src/taiga/stories/comments/api.py
@@ -5,6 +5,7 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
+from functools import partial
 from uuid import UUID
 
 from fastapi import Depends, Response
@@ -59,11 +60,9 @@ async def create_story_comments(
     story = await get_story_or_404(project_id=project_id, ref=ref)
     await check_permissions(permissions=CREATE_STORY_COMMENT, user=request.user, obj=story)
 
+    event_on_create = partial(events.emit_event_when_story_comment_is_created, project=story.project)
     return await comments_services.create_comment(
-        text=form.text,
-        content_object=story,
-        created_by=request.user,
-        event_on_create=events.emit_event_when_story_comment_is_created,
+        text=form.text, content_object=story, created_by=request.user, event_on_create=event_on_create
     )
 
 
@@ -130,11 +129,9 @@ async def update_story_comments(
     await check_permissions(permissions=UPDATE_STORY_COMMENT, user=request.user, obj=comment)
 
     values = form.dict(exclude_unset=True)
+    event_on_update = partial(events.emit_event_when_story_comment_is_updated, project=story.project)
     return await comments_services.update_comment(
-        story=story,
-        comment=comment,
-        values=values,
-        event_on_update=events.emit_event_when_story_comment_is_updated,
+        story=story, comment=comment, values=values, event_on_update=event_on_update
     )
 
 
@@ -163,10 +160,9 @@ async def delete_story_comment(
     comment = await get_story_comment_or_404(comment_id=comment_id, story=story)
     await check_permissions(permissions=DELETE_STORY_COMMENT, user=request.user, obj=comment)
 
+    event_on_delete = partial(events.emit_event_when_story_comment_is_deleted, project=story.project)
     return await comments_services.delete_comment(
-        comment=comment,
-        deleted_by=request.user,
-        event_on_delete=events.emit_event_when_story_comment_is_deleted,
+        comment=comment, deleted_by=request.user, event_on_delete=event_on_delete
     )
 
 

--- a/python/apps/taiga/src/taiga/stories/comments/events/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/comments/events/__init__.py
@@ -23,8 +23,8 @@ DELETE_STORY_COMMENT = "stories.comments.delete"
 
 
 async def emit_event_when_story_comment_is_created(
-    project: Project,
     comment: Comment,
+    project: Project,
 ) -> None:
     story = cast(Story, comment.content_object)
 
@@ -39,8 +39,8 @@ async def emit_event_when_story_comment_is_created(
 
 
 async def emit_event_when_story_comment_is_updated(
-    project: Project,
     comment: Comment,
+    project: Project,
 ) -> None:
     story = cast(Story, comment.content_object)
 
@@ -55,8 +55,8 @@ async def emit_event_when_story_comment_is_updated(
 
 
 async def emit_event_when_story_comment_is_deleted(
-    project: Project,
     comment: Comment,
+    project: Project,
 ) -> None:
     story = cast(Story, comment.content_object)
 

--- a/python/apps/taiga/tests/unit/taiga/comments/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/comments/test_services.py
@@ -65,7 +65,7 @@ async def test_create_comment_and_emit_event_on_create():
             text=comment.text,
             created_by=comment.created_by,
         )
-        fake_event_on_create.assert_awaited_once_with(project=comment.project, comment=comment)
+        fake_event_on_create.assert_awaited_once_with(comment=comment)
 
 
 #####################################################
@@ -164,7 +164,7 @@ async def test_update_comment_and_emit_event_on_update():
             comment=comment, values={"text": updated_text}
         )
 
-        fake_event_on_update.assert_awaited_once_with(project=comment.project, comment=comment)
+        fake_event_on_update.assert_awaited_once_with(comment=comment)
 
 
 ##########################################################
@@ -228,4 +228,4 @@ async def test_delete_comment_and_emit_event_on_delete():
                 "deleted_at": updated_comment.deleted_at,
             },
         )
-        fake_event_on_delete.assert_awaited_once_with(project=comment.project, comment=updated_comment)
+        fake_event_on_delete.assert_awaited_once_with(comment=updated_comment)


### PR DESCRIPTION
![](https://media.giphy.com/media/kWe1TwwSgzpfy3PqR5/giphy-downsized.gif)

This PR fixes a bug in the way we are generating the events for comments.

How to review:
- [x] reproduce the bug in main - being a django superuser try to delete a comment - returns a 500
- [x] check the code
- [x] tests are green
- [x] run front (main) and back (pr branch) and check again - now the comment is properly deleted