### PR TITLE
fix: remove invalid code

### DIFF
--- a/python/apps/taiga/src/taiga/comments/models.py
+++ b/python/apps/taiga/src/taiga/comments/models.py
@@ -40,9 +40,6 @@ class Comment(
         indexes = [
             models.Index(fields=["object_content_type", "object_id"]),
         ]
-        models.UniqueConstraint(
-            fields=["content_type", "object_id"], name="%(app_label)s_%(class)s_unique_content_type-object_id"
-        )
         ordering = ["object_content_type", "object_id", "-created_at"]
 
     def __str__(self) -> str:


### PR DESCRIPTION
- The constraint is not assigned to `constraints` attribute.
- The field should be "object_content_type" and not "content_type"
- If this constraint is applied, every related object (identify by "object_content_type" and "object_id") can only have one comment.