### PR TITLE
 [back] feat(notifications): u#2899 mark notification as read

### DIFF
--- a/python/apps/taiga/src/taiga/notifications/events/__init__.py
+++ b/python/apps/taiga/src/taiga/notifications/events/__init__.py
@@ -6,10 +6,12 @@
 # Copyright (c) 2023-present Kaleidos INC
 
 from taiga.events import events_manager
-from taiga.notifications.events.content import CreateNotificationContent
+from taiga.notifications.events.content import CreateNotificationContent, ReadNotificationsContent
 from taiga.notifications.models import Notification
+from taiga.users.models import User
 
 CREATE_NOTIFICATION = "notifications.create"
+READ_NOTIFICATIONS = "notifications.read"
 
 
 async def emit_event_when_notifications_are_created(
@@ -23,3 +25,13 @@ async def emit_event_when_notifications_are_created(
                 notification=notification,
             ),
         )
+
+
+async def emit_event_when_notifications_are_read(user: User, notifications: list[Notification]) -> None:
+    await events_manager.publish_on_user_channel(
+        user=user,
+        type=READ_NOTIFICATIONS,
+        content=ReadNotificationsContent(
+            notifications_ids=[n.id for n in notifications],
+        ),
+    )

--- a/python/apps/taiga/src/taiga/notifications/events/content.py
+++ b/python/apps/taiga/src/taiga/notifications/events/content.py
@@ -5,9 +5,13 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
-from taiga.base.serializers import BaseModel
+from taiga.base.serializers import UUIDB64, BaseModel
 from taiga.notifications.serializers import NotificationSerializer
 
 
 class CreateNotificationContent(BaseModel):
     notification: NotificationSerializer
+
+
+class ReadNotificationsContent(BaseModel):
+    notifications_ids: list[UUIDB64]

--- a/python/apps/taiga/tests/integration/taiga/notifications/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/notifications/test_repositories.py
@@ -63,6 +63,39 @@ async def test_list_notifications_filters():
 
 
 ##########################################################
+# get_notification
+##########################################################
+
+
+async def test_get_notification():
+    user1 = await f.create_user()
+    user2 = await f.create_user()
+    notification = await f.create_notification(owner=user1)
+
+    assert await repositories.get_notification(filters={"id": notification.id}) == notification
+    assert await repositories.get_notification(filters={"id": notification.id, "owner": user1}) == notification
+    assert await repositories.get_notification(filters={"id": notification.id, "owner": user2}) is None
+
+
+##########################################################
+# mark notifications as read
+##########################################################
+
+
+async def test_mark_notifications_as_read():
+    user = await f.create_user()
+    n1 = await f.create_notification(owner=user)
+    n2 = await f.create_notification(owner=user)
+    n3 = await f.create_notification(owner=user)
+
+    assert n1.read_at == n2.read_at == n3.read_at is None
+
+    ns = await repositories.mark_notifications_as_read(filters={"owner": user})
+
+    assert ns[0].read_at == ns[1].read_at == ns[2].read_at is not None
+
+
+##########################################################
 # misc
 ##########################################################
 

--- a/python/apps/taiga/tests/utils/factories/notifications.py
+++ b/python/apps/taiga/tests/utils/factories/notifications.py
@@ -7,11 +7,12 @@
 
 from asgiref.sync import sync_to_async
 
-from .base import Factory
+from .base import Factory, factory
 
 
 class NotificationFactory(Factory):
     type = "test_notification"
+    owner = factory.SubFactory("tests.utils.factories.UserFactory")
 
     class Meta:
         model = "notifications.Notification"

--- a/python/docs/events.md
+++ b/python/docs/events.md
@@ -944,3 +944,20 @@ Content for:
       "notification": {... "notification object" ...},
   }
   ```
+
+
+#### `notifications.read`
+
+It happens when one or some notifications are marked as read.
+
+Content for:
+- user channel:
+  ```
+  {
+      "notifications_ids": [
+        "notification id 1",
+        "notification id 2",
+        ...
+      ]
+  }
+  ```

--- a/python/docs/postman/taiga.postman_collection.json
+++ b/python/docs/postman/taiga.postman_collection.json
@@ -3800,7 +3800,7 @@
 							],
 							"query": [
 								{
-									"key": "read",
+									"key": "is_read",
 									"value": "false",
 									"description": "boolean or none",
 									"disabled": true
@@ -3854,6 +3854,49 @@
 									"value": null,
 									"disabled": true
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "mark my notification as read",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/notifications/{{notification_id}}/read",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"my",
+								"notifications",
+								"{{notification_id}}",
+								"read"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_collection_e2e.json
+++ b/python/docs/postman/taiga.postman_collection_e2e.json
@@ -10882,8 +10882,6 @@
 							"listen": "test",
 							"script": {
 								"exec": [
-									"// Post-request execution tasks",
-									"",
 									"// Tests",
 									"pm.test(\"HTTP status code is correct\", function () {",
 									"    pm.response.to.have.status(200);",
@@ -10903,6 +10901,11 @@
 									"    // Validate we're not returning more fields than expected",
 									"    var numOfReturnedFields = Object.keys(jsonRes[0]).length;",
 									"    pm.expect(numOfReturnedFields).to.equal(6);",
+									"});",
+									"",
+									"// Post-request execution tasks",
+									"pm.test(\"Environment variable settings\", function () {",
+									"    pm.environment.set(\"notification_id\", pm.response.json()[0].id);",
 									"});"
 								],
 								"type": "text/javascript"
@@ -10923,7 +10926,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/notifications?read=false",
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/notifications?is_read=false",
 							"protocol": "{{protocol}}",
 							"host": [
 								"{{domain}}{{port}}{{api_url}}"
@@ -10934,9 +10937,75 @@
 							],
 							"query": [
 								{
-									"key": "read",
+									"key": "is_read",
 									"value": "false"
 								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "200 my.notiffications.{id}.read",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Post-request execution tasks",
+									"",
+									"// Tests",
+									"pm.test(\"HTTP status code is correct\", function () {",
+									"    pm.response.to.have.status(200);",
+									"",
+									"});",
+									"pm.test(\"Response JSON is correct\", function () {",
+									"    var jsonRes = pm.response.json();",
+									"",
+									"    // Validate response API contract for each element",
+									"    pm.expect(jsonRes).to.have.property(\"id\");",
+									"    pm.expect(jsonRes).to.have.property(\"type\");",
+									"    pm.expect(jsonRes).to.have.property(\"createdBy\");",
+									"    pm.expect(jsonRes).to.have.property(\"createdAt\");",
+									"    pm.expect(jsonRes).to.have.property(\"readAt\");",
+									"    pm.expect(jsonRes).to.have.property(\"content\");",
+									"    ",
+									"    // Validate we're not returning more fields than expected",
+									"    var numOfReturnedFields = Object.keys(jsonRes).length;",
+									"    pm.expect(numOfReturnedFields).to.equal(6);",
+									"",
+									"    // notification must be read",
+									"    pm.expect(jsonRes.readAt).to.not.be.null;",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{auth_token}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{domain}}{{port}}{{api_url}}/my/notifications/{{notification_id}}/read",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{domain}}{{port}}{{api_url}}"
+							],
+							"path": [
+								"my",
+								"notifications",
+								"{{notification_id}}",
+								"read"
 							]
 						}
 					},

--- a/python/docs/postman/taiga.postman_environment.json
+++ b/python/docs/postman/taiga.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "efd6baad-f9ca-4c79-b9c7-a8ce54b3745d",
+	"id": "feaed8c3-8ebf-450f-9e02-1ddc91a8cdbd",
 	"name": "Taiga Next",
 	"values": [
 		{
@@ -20,11 +20,6 @@
 		{
 			"key": "api_url",
 			"value": "/api/v2",
-			"enabled": true
-		},
-		{
-			"key": "auth_token",
-			"value": "",
 			"enabled": true
 		},
 		{
@@ -50,11 +45,6 @@
 		{
 			"key": "us_version",
 			"value": "1",
-			"enabled": true
-		},
-		{
-			"key": "refresh_token",
-			"value": "",
 			"enabled": true
 		},
 		{
@@ -197,9 +187,33 @@
 			"value": "",
 			"type": "any",
 			"enabled": true
+		},
+		{
+			"key": "auth_token",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "refresh_token",
+			"value": "",
+			"type": "any",
+			"enabled": true
+		},
+		{
+			"key": "notification_id\n",
+			"value": "",
+			"type": "default",
+			"enabled": true
+		},
+		{
+			"key": "notification_id",
+			"value": "",
+			"type": "any",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2023-09-13T11:28:54.663Z",
-	"_postman_exported_using": "Postman/10.17.2"
+	"_postman_exported_at": "2023-10-18T17:09:55.408Z",
+	"_postman_exported_using": "Postman/10.18.11"
 }


### PR DESCRIPTION
<div align="center">

  ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODFybXk3NXY2cGRwdWRpa21wbW45dmdybDh0bmxmazZvbHJqa3FlaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l4FGp7yJRMJLPsXuw/giphy.gif)

</div>

This PR add an endpoint to mark one notifications as read. It is a POST call with an empty body

```
POST /my/notifications/{id}/read
```

### HOW TO VALIDATE:

- [x] Review the code
- [x] Roses are red and test are green.
- [x] Manual tests:
  - Create a notification (assign a story to any user, not you).
  - Call to the new endpoint (with postman or something similar)
    - the response should contain the notification with the current datetime settled in `readAt`
    - there is a new event `notifications.read` with a list of notifications ids marked as read
