### PR TITLE
[back] feat(notifications): u#2900 notify when the status of a story has changed

### DIFF
--- a/python/apps/taiga/src/taiga/stories/stories/notifications/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/notifications/__init__.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from taiga.notifications import services as notifications_services
+from taiga.stories.stories.models import Story
+from taiga.stories.stories.notifications.content import StoryStatusChangeNotificationContent
+from taiga.users.models import User
+
+STORIES_STATUS_CHANGE = "stories.status_change"
+
+
+async def notify_when_story_status_change(story: Story, status: str, emitted_by: User) -> None:
+    """
+    Emit notification when a story status changes
+    """
+    notified_users = {u async for u in story.assignees.all()}
+    if story.created_by:
+        notified_users.add(story.created_by)
+    notified_users.discard(emitted_by)
+
+    await notifications_services.notify_users(
+        type=STORIES_STATUS_CHANGE,
+        emitted_by=emitted_by,
+        notified_users=notified_users,
+        content=StoryStatusChangeNotificationContent(
+            projects=story.project,
+            story=story,
+            changed_by=emitted_by,
+            status=status,
+        ),
+    )

--- a/python/apps/taiga/src/taiga/stories/stories/notifications/content.py
+++ b/python/apps/taiga/src/taiga/stories/stories/notifications/content.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from taiga.base.serializers import BaseModel
+from taiga.projects.projects.serializers.nested import ProjectLinkNestedSerializer
+from taiga.stories.stories.serializers.nested import StoryNestedSerializer
+from taiga.users.serializers.nested import UserNestedSerializer
+
+
+class StoryStatusChangeNotificationContent(BaseModel):
+    projects: ProjectLinkNestedSerializer
+    story: StoryNestedSerializer
+    changed_by: UserNestedSerializer
+    status: str
+
+    class Config:
+        orm_mode = True

--- a/python/apps/taiga/src/taiga/stories/stories/repositories.py
+++ b/python/apps/taiga/src/taiga/stories/stories/repositories.py
@@ -235,6 +235,8 @@ def list_stories_to_reorder(filters: StoryFilters = {}) -> list[Story]:
     the order of the input references.
     """
     qs = _apply_filters_to_queryset(qs=DEFAULT_QUERYSET, filters=filters)
+    qs = _apply_select_related_to_queryset(qs=qs, select_related=["status", "project", "created_by"])
+    qs = _apply_prefetch_related_to_queryset(qs=qs, prefetch_related=["assignees"])
 
     stories = {s.ref: s for s in qs}
     return [stories[ref] for ref in filters["refs"] if stories.get(ref) is not None]

--- a/python/apps/taiga/src/taiga/workflows/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/api/__init__.py
@@ -287,6 +287,7 @@ async def delete_workflow_status(
     await check_permissions(permissions=DELETE_WORKFLOW_STATUS, user=request.user, obj=workflow_status)
 
     await workflows_services.delete_workflow_status(
+        deleted_by=request.user,
         workflow_status=workflow_status,
         target_status_id=query_params.move_to,  # type: ignore
     )

--- a/python/apps/taiga/tests/integration/taiga/stories/stories/test_services.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/stories/test_services.py
@@ -37,6 +37,7 @@ async def test_not_reorder_in_empty_status() -> None:
     # | story3   |          |
 
     await services.reorder_stories(
+        reordered_by=project.created_by,
         project=project,
         workflow=workflow,
         target_status_id=status_2.id,
@@ -72,7 +73,11 @@ async def test_not_reorder_in_populated_status() -> None:
     # | story2   |          |
 
     await services.reorder_stories(
-        project=project, workflow=workflow, target_status_id=status_2.id, stories_refs=[story2.ref]
+        reordered_by=project.created_by,
+        project=project,
+        workflow=workflow,
+        target_status_id=status_2.id,
+        stories_refs=[story2.ref],
     )
     # Now should be
     # | status_1 | status_2 |
@@ -103,6 +108,7 @@ async def test_after_in_the_end() -> None:
     # | story2   |          |
 
     await services.reorder_stories(
+        reordered_by=project.created_by,
         project=project,
         workflow=workflow,
         target_status_id=status_2.id,
@@ -138,6 +144,7 @@ async def test_after_in_the_middle() -> None:
     # |          | story3   |
 
     await services.reorder_stories(
+        reordered_by=project.created_by,
         project=project,
         workflow=workflow,
         target_status_id=status_2.id,
@@ -175,6 +182,7 @@ async def test_before_in_the_beginning() -> None:
     # |          | story3   |
 
     await services.reorder_stories(
+        reordered_by=project.created_by,
         project=project,
         workflow=workflow,
         target_status_id=status_2.id,
@@ -212,6 +220,7 @@ async def test_before_in_the_middle() -> None:
     # |          | story3   |
 
     await services.reorder_stories(
+        reordered_by=project.created_by,
         project=project,
         workflow=workflow,
         target_status_id=status_2.id,

--- a/python/apps/taiga/tests/unit/taiga/workflows/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/workflows/test_services.py
@@ -345,6 +345,7 @@ async def test_reorder_any_workflow_status_does_not_exist():
 
 
 async def test_delete_workflow_status_moving_stories_ok():
+    user = f.create_user()
     workflow = f.build_workflow()
     workflow_status1 = f.build_workflow_status(workflow=workflow)
     workflow_status2 = f.build_workflow_status(workflow=workflow)
@@ -362,7 +363,9 @@ async def test_delete_workflow_status_moving_stories_ok():
         fake_stories_repo.list_stories.return_value = workflow_status1_stories
         fake_stories_services.reorder_stories.return_value = None
 
-        await services.delete_workflow_status(workflow_status=workflow_status1, target_status_id=workflow_status2.id)
+        await services.delete_workflow_status(
+            workflow_status=workflow_status1, target_status_id=workflow_status2.id, deleted_by=user
+        )
 
         fake_get_workflow_status.assert_awaited_once_with(
             project_id=workflow.project.id, workflow_slug=workflow.slug, id=workflow_status2.id
@@ -374,6 +377,7 @@ async def test_delete_workflow_status_moving_stories_ok():
             order_by=["order"],
         )
         fake_stories_services.reorder_stories.assert_awaited_once_with(
+            reordered_by=user,
             project=workflow_status1.project,
             workflow=workflow,
             target_status_id=workflow_status2.id,
@@ -388,6 +392,7 @@ async def test_delete_workflow_status_moving_stories_ok():
 
 
 async def test_delete_workflow_status_deleting_stories_ok():
+    user = f.create_user()
     workflow = f.build_workflow()
     workflow_status1 = f.build_workflow_status(workflow=workflow)
     workflow_status1_stories = [f.build_story(status=workflow_status1, workflow=workflow)]
@@ -404,7 +409,7 @@ async def test_delete_workflow_status_deleting_stories_ok():
         fake_stories_repo.list_stories.return_value = workflow_status1_stories
         fake_stories_services.reorder_stories.return_value = None
 
-        await services.delete_workflow_status(workflow_status=workflow_status1, target_status_id=None)
+        await services.delete_workflow_status(workflow_status=workflow_status1, target_status_id=None, deleted_by=user)
 
         fake_get_workflow_status.assert_not_awaited()
         fake_stories_repo.list_stories.assert_not_awaited()
@@ -416,6 +421,7 @@ async def test_delete_workflow_status_deleting_stories_ok():
 
 
 async def test_delete_workflow_status_wrong_target_status_ex():
+    user = f.create_user()
     workflow = f.build_workflow()
     workflow_status1 = f.build_workflow_status(workflow=workflow)
     workflow_status2 = f.build_workflow_status(workflow=workflow)
@@ -426,7 +432,9 @@ async def test_delete_workflow_status_wrong_target_status_ex():
     ):
         fake_get_workflow_status.return_value = None
 
-        await services.delete_workflow_status(workflow_status=workflow_status1, target_status_id=workflow_status2.id)
+        await services.delete_workflow_status(
+            workflow_status=workflow_status1, target_status_id=workflow_status2.id, deleted_by=user
+        )
 
         fake_get_workflow_status.assert_awaited_once_with(
             project_id=workflow.project.id, workflow_slug=workflow.slug, id=workflow_status2.id
@@ -434,6 +442,7 @@ async def test_delete_workflow_status_wrong_target_status_ex():
 
 
 async def test_delete_workflow_status_same_target_status_ex():
+    user = f.create_user()
     workflow = f.build_workflow()
     workflow_status1 = f.build_workflow_status(workflow=workflow)
 
@@ -443,7 +452,9 @@ async def test_delete_workflow_status_same_target_status_ex():
     ):
         fake_get_workflow_status.return_value = workflow_status1
 
-        await services.delete_workflow_status(workflow_status=workflow_status1, target_status_id=workflow_status1.id)
+        await services.delete_workflow_status(
+            workflow_status=workflow_status1, target_status_id=workflow_status1.id, deleted_by=user
+        )
 
         fake_get_workflow_status.assert_awaited_once_with(
             project_id=workflow.project.id, workflow_slug=workflow.slug, id=workflow_status1.id


### PR DESCRIPTION
<div align="center">

![](https://media.giphy.com/media/NQUEuFXT1eLH44cyoP/giphy-downsized.gif)

</div>


This PR notifies assigned users and its creator when the story changes its status.

This can happen: 
- In kanban, when a story changes to another column.
- From the detail panel of a story, through the status selector.
- When a state is deleted and its stories are requested to move to another


## How to validate:

- [x] Review the code
- [x] Roses are red and tests are green
- Manual test. Notifications must be created when some user...
  - [x] Move stories in the kanban
  - [x] Change status in the story's detail panel
  - [x] Remove status moving stories to another status