### PR TITLE
Update config.sh. Fix syntax error

### DIFF
--- a/docker/images/config.sh
+++ b/docker/images/config.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/sh
 
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Fix syntax error and use interpreter, which is used in other config .sh scripts in docker build