### PR TITLE
feat(notifications): u#3985 notify when a story has changed workflow (and status)

### DIFF
--- a/python/apps/taiga/src/taiga/stories/stories/notifications/content.py
+++ b/python/apps/taiga/src/taiga/stories/stories/notifications/content.py
@@ -28,3 +28,14 @@ class StoryStatusChangeNotificationContent(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class StoryWorkflowChangeNotificationContent(BaseModel):
+    project: ProjectLinkNestedSerializer
+    story: StoryNestedSerializer
+    changed_by: UserNestedSerializer
+    status: str
+    workflow: str
+
+    class Config:
+        orm_mode = True

--- a/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
@@ -197,7 +197,14 @@ async def update_story(
     )
 
     # Emit notifications
-    if "status" in update_values:
+    if "workflow" in update_values:
+        await stories_notifications.notify_when_story_workflow_change(
+            story=story,
+            workflow=update_values["workflow"].name,
+            status=update_values["status"].name,
+            emitted_by=updated_by,
+        )
+    elif "status" in update_values:
         await stories_notifications.notify_when_story_status_change(
             story=story,
             status=update_values["status"].name,

--- a/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
@@ -250,6 +250,7 @@ async def test_update_story_ok():
             updates_attrs=[*values],
         )
         fake_notifications.notify_when_story_status_change.assert_not_awaited()
+        fake_notifications.notify_when_story_workflow_change.assert_not_awaited()
 
         assert updated_story == detailed_story
 
@@ -324,7 +325,8 @@ async def test_update_story_workflow_ok():
             updates_attrs=[*values],
         )
 
-        fake_notifications.notify_when_story_status_change.assert_awaited_once()
+        fake_notifications.notify_when_story_status_change.assert_not_awaited()
+        fake_notifications.notify_when_story_workflow_change.assert_awaited_once()
 
 
 async def test_update_story_error_wrong_version():
@@ -365,6 +367,7 @@ async def test_update_story_error_wrong_version():
         fake_get_story_detail.assert_not_awaited()
         fake_stories_events.emit_event_when_story_is_updated.assert_not_awaited()
         fake_notifications.notify_when_story_status_change.assert_not_awaited()
+        fake_notifications.notify_when_story_workflow_change.assert_not_awaited()
 
 
 #######################################################


### PR DESCRIPTION
This PR emits notifications after someone changes the story workflow (and status).
Who is notified?
- the story creator (given that she is not the one changing the story)
- each of the assigned user (except the one who is changing the story)

How to review:
- [x] check the code
- [x] tests are green
- [x] run back and front
- [x] user1 creates a story and assigns user2. user3 changes the workflow of the story 
- [x] two notifications are created: for user1 and user2