### PR TITLE
feat(delete-worflow): move just not-empty statuses

### DIFF
--- a/python/apps/taiga/src/taiga/workflows/api/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/api/__init__.py
@@ -181,10 +181,7 @@ async def delete_workflow(
     workflow = await get_workflow_or_404(project_id=project_id, workflow_slug=workflow_slug)
     await check_permissions(permissions=DELETE_WORKFLOW, user=request.user, obj=workflow)
 
-    await workflows_services.delete_workflow(
-        workflow=workflow,
-        target_workflow_slug=query_params.move_to,
-    )
+    await workflows_services.delete_workflow(workflow=workflow, target_workflow_slug=query_params.move_to)
 
 
 ################################################

--- a/python/apps/taiga/src/taiga/workflows/services/__init__.py
+++ b/python/apps/taiga/src/taiga/workflows/services/__init__.py
@@ -188,7 +188,7 @@ async def delete_workflow(workflow: Workflow, target_workflow_slug: str | None =
             raise ex.SameMoveToWorkflow("The to-be-deleted workflow and the target-workflow cannot be the same")
 
         statuses_to_move = await workflows_repositories.list_workflow_statuses(
-            filters={"workflow_id": workflow.id},
+            filters={"workflow_id": workflow.id, "is_empty": False},
             order_by=["order"],
         )
 

--- a/python/apps/taiga/tests/unit/taiga/workflows/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/workflows/test_services.py
@@ -361,7 +361,7 @@ async def test_delete_workflow_with_target_workflow_with_anchor_status_ok():
         # asserts
         fake_workflows_repo.list_workflow_statuses.assert_has_awaits(
             [
-                call(filters={"workflow_id": deleted_workflow.id}, order_by=["order"]),
+                call(filters={"workflow_id": deleted_workflow.id, "is_empty": False}, order_by=["order"]),
                 call(filters={"workflow_id": target_workflow.id}, order_by=["-order"], offset=0, limit=1),
             ]
         )
@@ -434,7 +434,7 @@ async def test_delete_workflow_with_target_workflow_with_no_anchor_status_ok():
         # asserts
         fake_workflows_repo.list_workflow_statuses.assert_has_awaits(
             [
-                call(filters={"workflow_id": deleted_workflow.id}, order_by=["order"]),
+                call(filters={"workflow_id": deleted_workflow.id, "is_empty": False}, order_by=["order"]),
                 call(filters={"workflow_id": target_workflow.id}, order_by=["-order"], offset=0, limit=1),
             ]
         )


### PR DESCRIPTION
This PR avoids to preserve empty statuses (those ones without stories), when deleting a workflow and specifying to move its existing statuses.

![gif](https://media.giphy.com/media/CHZCRSsuQAshi/giphy.gif)

### What to test

- [x] Review the code
- [x] Tests are green
- [x] Run back and front
- [x] Create a workflow1 with a story in any of its default statuses (new, ready, in.progress and done)
- [x] Delete workflow1, specifying to move its statuses to main
- [x] Main will have a new status, the one containing the story
- [x] Create a workflow2 without creating any further story
- [x] Delete workflow2, specifying to move its statuses to main
- [x] Main will have the same previous statuses with no new status
