### PR TITLE
issue(story): #4114 validate not being updated both workflow and status

### DIFF
--- a/python/apps/taiga/src/taiga/stories/stories/api/validators.py
+++ b/python/apps/taiga/src/taiga/stories/stories/api/validators.py
@@ -8,6 +8,7 @@
 from typing import Any
 
 from pydantic import ConstrainedStr, conlist, validator
+from pydantic.class_validators import root_validator
 from pydantic.types import PositiveInt
 from taiga.base.validators import B64UUID, BaseModel
 
@@ -30,6 +31,13 @@ class UpdateStoryValidator(BaseModel):
     description: str | None
     status: B64UUID | None
     workflow: str | None
+
+    @root_validator
+    def status_or_workflow(cls, values: dict[Any, Any]) -> dict[Any, Any]:
+        status = values.get("status")
+        workflow = values.get("workflow")
+        assert not (status and workflow), "It's not allowed to update both the status and workspace"
+        return values
 
 
 class ReorderValidator(BaseModel):

--- a/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
+++ b/python/apps/taiga/src/taiga/stories/stories/services/__init__.py
@@ -235,7 +235,7 @@ async def _validate_and_process_values_to_update(
         status = await workflows_repositories.get_workflow_status(
             filters={"workflow_id": story.workflow_id, "id": status_id}
         )
-        if not status:
+        if not status or output.get("workflow", None):
             raise ex.InvalidStatusError("The provided status is not valid.")
 
         if status.id != story.status_id:

--- a/python/apps/taiga/tests/integration/taiga/stories/stories/test_api.py
+++ b/python/apps/taiga/tests/integration/taiga/stories/stories/test_api.py
@@ -360,6 +360,15 @@ async def test_update_story_422_unprocessable_story_ref(client):
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
 
 
+async def test_update_story_422_unprocessable_both_workflow_and_status(client):
+    project = await f.create_project()
+
+    data = {"version": 1, "workflow": "workflow-slug", "status": project.b64id}
+    client.login(project.created_by)
+    response = client.patch(f"/projects/{project.b64id}/stories/1", json=data)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY, response.text
+
+
 async def test_update_story_404_not_found_project_b64id(client):
     project = await f.create_project()
     story = await f.create_story(project=project)

--- a/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
+++ b/python/apps/taiga/tests/unit/taiga/stories/stories/test_services.py
@@ -614,6 +614,22 @@ async def test_validate_and_process_values_to_update_error_workflow_without_stat
         fake_stories_repo.list_stories.assert_not_awaited()
 
 
+async def test_validate_and_process_values_to_update_error_workflow_and_status():
+    user = f.build_user()
+    project = f.build_project()
+    workflow1 = f.build_workflow(project=project)
+    status1 = f.build_workflow_status(workflow=workflow1)
+    story = f.build_story(project=project, workflow=workflow1, status=status1)
+    workflow2 = f.build_workflow(project=project, statuses=None)
+    values = {"version": story.version, "status": status1, "workflow": workflow2.slug}
+
+    with (patch("taiga.stories.stories.services.workflows_repositories", autospec=True) as fake_workflows_repo,):
+        fake_workflows_repo.get_workflow_status.return_value = workflow2
+
+        with pytest.raises(ex.InvalidStatusError):
+            await services._validate_and_process_values_to_update(story=story, values=values, updated_by=user)
+
+
 #######################################################
 # _calculate_offset
 #######################################################


### PR DESCRIPTION
Avoids to update a status and a workflow simultaneously for a story. It's been fixed both in the api and the service layer.

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmZnZ3NnNWZ0NmZkMXR6bjVkb3U3ZjE1bTltcnh4bXpjanA4ZTdyNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QydOVgahElhEYVih6Q/giphy.gif)

[Reported issue](https://tree.taiga.io/project/taiga-next/issue/4114) in Taiga (see the comments).

### What to test
- [ ] Reproduce the 500 error in the main branch (according to the reported issue), using these parameters:

```
// call api/v2/projects/FDx4mH1tEe6N1LQumfCfHA/stories/18
{
  "ref": 18,
  "version": 8,
  "workflow": "new-workflow"
  "status": "another-status-in-current-workflow",
}
```
- [x] Change to the PR's branch and repeat the same previous request. It returns a 422 unprocessable error.
- [x] It allows to change the story's status to another one in the same workflow
- [x] It allows to change the story's workflow to another one
- [x] Hi five