### PR TITLE
[BACK] feat(notifications): u#3965 add a periodic task and a command to delete read notifications

### DIFF
--- a/python/apps/taiga/src/taiga/__main__.py
+++ b/python/apps/taiga/src/taiga/__main__.py
@@ -35,6 +35,7 @@ from taiga.base.i18n.commands import cli as i18n_cli
 from taiga.base.sampledata.commands import cli as sampledata_cli
 from taiga.commons.storage.commands import cli as storage_cli
 from taiga.emails.commands import cli as emails_cli
+from taiga.notifications.commands import cli as notifications_cli
 from taiga.tasksqueue.commands import cli as tasksqueue_cli
 from taiga.tasksqueue.commands import init as init_tasksqueue
 from taiga.tasksqueue.commands import run_worker, worker
@@ -69,9 +70,10 @@ def main(
 cli.add_typer(db_cli, name="db")
 cli.add_typer(emails_cli, name="emails")
 cli.add_typer(i18n_cli, name="i18n")
+cli.add_typer(notifications_cli, name="notifications")
 cli.add_typer(sampledata_cli, name="sampledata")
-cli.add_typer(tasksqueue_cli, name="tasksqueue")
 cli.add_typer(storage_cli, name="storage")
+cli.add_typer(tasksqueue_cli, name="tasksqueue")
 cli.add_typer(tokens_cli, name="tokens")
 cli.add_typer(users_cli, name="users")
 

--- a/python/apps/taiga/src/taiga/commons/storage/commands.py
+++ b/python/apps/taiga/src/taiga/commons/storage/commands.py
@@ -27,7 +27,7 @@ def clean_storaged_objects(
         settings.STORAGE.DAYS_TO_STORE_DELETED_STORAGED_OBJECTS,
         "--days",
         "-d",
-        help="Number of days to store deleted storaged objects",
+        help="Delete all storaged object deleted before the specified days",
     ),
 ) -> None:
     total_deleted = run_async_as_sync(

--- a/python/apps/taiga/src/taiga/conf/__init__.py
+++ b/python/apps/taiga/src/taiga/conf/__init__.py
@@ -17,6 +17,7 @@ from taiga.conf.emails import EmailSettings
 from taiga.conf.events import EventsSettings
 from taiga.conf.images import ImageSettings
 from taiga.conf.logs import LOGGING_CONFIG
+from taiga.conf.notifications import NotificationsSettings
 from taiga.conf.storage import StorageSettings
 from taiga.conf.tasksqueue import TaskQueueSettings
 from taiga.conf.tokens import TokensSettings
@@ -102,6 +103,7 @@ class Settings(BaseSettings):
     EMAIL: EmailSettings = EmailSettings()
     EVENTS: EventsSettings = EventsSettings()
     IMAGES: ImageSettings = ImageSettings()
+    NOTIFICATIONS: NotificationsSettings = NotificationsSettings()
     STORAGE: StorageSettings = StorageSettings()
     TASKQUEUE: TaskQueueSettings = TaskQueueSettings()
     TOKENS: TokensSettings = TokensSettings()

--- a/python/apps/taiga/src/taiga/conf/notifications.py
+++ b/python/apps/taiga/src/taiga/conf/notifications.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from pydantic import BaseSettings
+
+
+class NotificationsSettings(BaseSettings):
+    CLEAN_READ_NOTIFICATIONS_CRON: str = "30 * * * *"  # default: every hour at minute 30.
+    MINUTES_TO_STORE_READ_NOTIFICATIONS: int = 2 * 60  # 120 minutes

--- a/python/apps/taiga/src/taiga/conf/tasksqueue.py
+++ b/python/apps/taiga/src/taiga/conf/tasksqueue.py
@@ -13,6 +13,7 @@ class TaskQueueSettings(BaseSettings):
     TASKS_MODULES_PATHS: set[str] = {
         "taiga.commons.storage.tasks",
         "taiga.emails.tasks",
+        "taiga.notifications.tasks",
         "taiga.projects.projects.tasks",
         "taiga.tokens.tasks",
         "taiga.users.tasks",

--- a/python/apps/taiga/src/taiga/notifications/commands.py
+++ b/python/apps/taiga/src/taiga/notifications/commands.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+from datetime import timedelta
+
+import typer
+from taiga.base.utils import pprint
+from taiga.base.utils.concurrency import run_async_as_sync
+from taiga.base.utils.datetime import aware_utcnow
+from taiga.conf import settings
+from taiga.notifications import services as notifications_services
+
+cli = typer.Typer(
+    name="Taiga Notifications commands",
+    help="Manage the notifications system of Taiga.",
+    add_completion=True,
+)
+
+
+@cli.command(help="Clean read notifications. Remove entries from DB.")
+def clean_read_notifications(
+    minutes_to_store_read_notifications: int = typer.Option(
+        settings.NOTIFICATIONS.MINUTES_TO_STORE_READ_NOTIFICATIONS,
+        "--minutes",
+        "-m",
+        help="Delete all notification read before the specified minutes",
+    ),
+) -> None:
+    total_deleted = run_async_as_sync(
+        notifications_services.clean_read_notifications(
+            before=aware_utcnow() - timedelta(minutes=minutes_to_store_read_notifications)
+        )
+    )
+
+    color = "red" if total_deleted else "white"
+    pprint.print(f"Deleted [bold][{color}]{total_deleted}[/{color}][/bold] notifications.")

--- a/python/apps/taiga/src/taiga/notifications/services.py
+++ b/python/apps/taiga/src/taiga/notifications/services.py
@@ -6,6 +6,7 @@
 # Copyright (c) 2023-present Kaleidos INC
 
 from collections.abc import Iterable
+from datetime import datetime
 from uuid import UUID
 
 from taiga.base.serializers import BaseModel
@@ -57,3 +58,7 @@ async def count_user_notifications(user: User) -> dict[str, int]:
     total = await notifications_repositories.count_notifications(filters={"owner": user})
     read = await notifications_repositories.count_notifications(filters={"owner": user, "is_read": True})
     return {"total": total, "read": read, "unread": total - read}
+
+
+async def clean_read_notifications(before: datetime) -> int:
+    return await notifications_repositories.delete_notifications(filters={"is_read": True, "read_before": before})

--- a/python/apps/taiga/src/taiga/notifications/tasks.py
+++ b/python/apps/taiga/src/taiga/notifications/tasks.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Copyright (c) 2023-present Kaleidos INC
+
+import logging
+from datetime import timedelta
+
+from taiga.base.utils.datetime import aware_utcnow
+from taiga.conf import settings
+from taiga.notifications import services as notifications_services
+from taiga.tasksqueue.manager import manager as tqmanager
+
+logger = logging.getLogger(__name__)
+
+
+@tqmanager.periodic(cron=settings.NOTIFICATIONS.CLEAN_READ_NOTIFICATIONS_CRON)  # type: ignore
+@tqmanager.task
+async def clean_read_notifications(timestamp: int) -> int:
+    total_deleted = await notifications_services.clean_read_notifications(
+        before=aware_utcnow() - timedelta(minutes=settings.NOTIFICATIONS.MINUTES_TO_STORE_READ_NOTIFICATIONS)
+    )
+
+    logger.info(
+        "deleted notifications: %s",
+        total_deleted,
+        extra={"deleted": total_deleted},
+    )
+
+    return total_deleted

--- a/python/apps/taiga/tests/integration/taiga/notifications/test_repositories.py
+++ b/python/apps/taiga/tests/integration/taiga/notifications/test_repositories.py
@@ -5,6 +5,8 @@
 #
 # Copyright (c) 2023-present Kaleidos INC
 
+from datetime import timedelta
+
 import pytest
 from taiga.base.utils.datetime import aware_utcnow
 from taiga.notifications import repositories
@@ -48,18 +50,21 @@ async def test_list_notifications_filters():
     user2 = await f.create_user()
     user3 = await f.create_user()
 
+    now = aware_utcnow()
+
     n11 = await f.create_notification(owner=user1, created_by=user3)
-    n12 = await f.create_notification(owner=user1, created_by=user3, read_at=aware_utcnow())
+    n12 = await f.create_notification(owner=user1, created_by=user3, read_at=now - timedelta(minutes=2))
     n13 = await f.create_notification(owner=user1, created_by=user3)
 
     n21 = await f.create_notification(owner=user2, created_by=user3)
-    n22 = await f.create_notification(owner=user2, created_by=user3, read_at=aware_utcnow())
+    n22 = await f.create_notification(owner=user2, created_by=user3, read_at=now - timedelta(minutes=1))
 
     assert [n22, n21, n13, n12, n11] == await repositories.list_notifications()
     assert [n13, n12, n11] == await repositories.list_notifications(filters={"owner": user1})
     assert [n13, n11] == await repositories.list_notifications(filters={"owner": user1, "is_read": False})
     assert [n12] == await repositories.list_notifications(filters={"owner": user1, "is_read": True})
     assert [n22, n12] == await repositories.list_notifications(filters={"is_read": True})
+    assert [n12] == await repositories.list_notifications(filters={"read_before": now - timedelta(minutes=1)})
 
 
 ##########################################################
@@ -93,6 +98,48 @@ async def test_mark_notifications_as_read():
     ns = await repositories.mark_notifications_as_read(filters={"owner": user})
 
     assert ns[0].read_at == ns[1].read_at == ns[2].read_at is not None
+
+
+##########################################################
+# delete notifications
+##########################################################
+
+
+async def test_delete_notifications():
+    user1 = await f.create_user()
+    user2 = await f.create_user()
+    user3 = await f.create_user()
+
+    now = aware_utcnow()
+
+    await f.create_notification(owner=user1, created_by=user3)
+    await f.create_notification(owner=user1, created_by=user3, read_at=now - timedelta(minutes=1))
+    await f.create_notification(owner=user1, created_by=user3, read_at=now - timedelta(minutes=2))
+
+    await f.create_notification(owner=user2, created_by=user3)
+    await f.create_notification(owner=user2, created_by=user3, read_at=now - timedelta(minutes=1))
+
+    assert 5 == await repositories.count_notifications()
+    assert 3 == await repositories.count_notifications(filters={"owner": user1})
+    assert 2 == await repositories.count_notifications(filters={"owner": user1, "is_read": True})
+    assert 2 == await repositories.count_notifications(filters={"owner": user2})
+    assert 1 == await repositories.count_notifications(filters={"owner": user2, "is_read": True})
+
+    await repositories.delete_notifications(filters={"read_before": now - timedelta(minutes=1)})
+
+    assert 4 == await repositories.count_notifications()
+    assert 2 == await repositories.count_notifications(filters={"owner": user1})
+    assert 1 == await repositories.count_notifications(filters={"owner": user1, "is_read": True})
+    assert 2 == await repositories.count_notifications(filters={"owner": user2})
+    assert 1 == await repositories.count_notifications(filters={"owner": user2, "is_read": True})
+
+    await repositories.delete_notifications(filters={"read_before": now})
+
+    assert 2 == await repositories.count_notifications()
+    assert 1 == await repositories.count_notifications(filters={"owner": user1})
+    assert 0 == await repositories.count_notifications(filters={"owner": user1, "is_read": True})
+    assert 1 == await repositories.count_notifications(filters={"owner": user2})
+    assert 0 == await repositories.count_notifications(filters={"owner": user2, "is_read": True})
 
 
 ##########################################################


### PR DESCRIPTION
<div align=center>

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZmhuYXYxYjVsbm5tcHU5MXB6bWtvMnUzZXoxeHlweXM5bjljajg1cCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/hFmIU5GQF18Aw/giphy.gif)

</div>

A periodic task is created that will delete delete all notifications that have been read more than X minutes ago. (The frequency of the periodic task and time that the nitifications will be kept are configurable parameters).

There is a CLI command to remove read notifications too.

### How to tests:

- [x] Review the code.
- [x] Tests are green.
- [x] Manual tests: Tests logical deletion:
    - Init:
        - Set settings to remove notifications read before 2 minutes.
          ```
          export TAIGA_NOTIFICATIONS__CLEAN_READ_NOTIFICATIONS_CRON= "* * * * *"
          export TAIGA_NOTIFICATIONS__MINUTES_TO_STORE_READ_NOTIFICATIONS=1
          ```
        - Open two frontend as 1user and 2user and go to the same kanban
    - Test periodic task: 
       - You have to create some notifications and mark as read. Then, wait a little bit (~ 2 minutes) and check the console logs to see the log entry of the periodic task runned.
    - Test CLI: 
       - `python -m taiga notifications clean-read-notifications --help`
    